### PR TITLE
[Feature - Mar 3rd, 2024]{Member} jwt 토큰, 필터, aop 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ dependencies {
     // security
     implementation 'org.springframework.security:spring-security-core:6.2.2'
 
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/runninghi/runninghibackv2/auth/aop/AuthorizationAspect.java
+++ b/src/main/java/com/runninghi/runninghibackv2/auth/aop/AuthorizationAspect.java
@@ -35,11 +35,11 @@ public class AuthorizationAspect {
         }
 
         HttpServletRequest request = attributes.getRequest();
-        String accessToken = jwtTokenProvider.extractAccessToken(request);
-        Role role = jwtTokenProvider.getRoleFromToken(accessToken);
+        String accessToken = jwtTokenProvider.extractAccessTokenFromRequest(request);
+        String role = jwtTokenProvider.getRoleFromToken(accessToken);
 
         // 권한 확인
-        if (Role.ADMIN != role) {
+        if (!Role.ADMIN.name().equals(role)) {
             throw new AccessDeniedException("Access Denied");
         }
 

--- a/src/main/java/com/runninghi/runninghibackv2/auth/aop/AuthorizationAspect.java
+++ b/src/main/java/com/runninghi/runninghibackv2/auth/aop/AuthorizationAspect.java
@@ -1,0 +1,49 @@
+package com.runninghi.runninghibackv2.auth.aop;
+
+import com.runninghi.runninghibackv2.auth.jwt.JwtTokenProvider;
+import com.runninghi.runninghibackv2.common.entity.Role;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AuthorizationAspect {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * @HasAccess 어노테이션이 붙은 메서드 실행 전 후에 권한을 확인하는 Around 어드바이스입니다.
+     *
+     * @param joinPoint 실행되는 조인 포인트
+     * @return 조인 포인트의 실행 결과
+     * @throws Throwable 실행 중 발생한 예외
+     */
+    @Around("@annotation(com.runninghi.runninghibackv2.common.annotations.HasAccess)")
+    public Object hasAccess(ProceedingJoinPoint joinPoint) throws Throwable {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+        if (attributes == null) {
+            throw new IllegalStateException("No current ServletRequestAttribute");
+        }
+
+        HttpServletRequest request = attributes.getRequest();
+        String accessToken = jwtTokenProvider.extractAccessToken(request);
+        Role role = jwtTokenProvider.getRoleFromToken(accessToken);
+
+        // 권한 확인
+        if (Role.ADMIN != role) {
+            throw new AccessDeniedException("Access Denied");
+        }
+
+        return joinPoint.proceed();
+    }
+
+}

--- a/src/main/java/com/runninghi/runninghibackv2/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/runninghi/runninghibackv2/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,194 @@
+package com.runninghi.runninghibackv2.auth.jwt;
+
+import com.runninghi.runninghibackv2.common.dto.MemberJwtInfo;
+import com.runninghi.runninghibackv2.common.entity.Role;
+import com.runninghi.runninghibackv2.common.exception.custom.InvalidTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final String secretKey;
+    private final long accessExpireMinutes;
+    private final long refreshExpireDays;
+    private final String issuer;
+
+    /**
+     * 지정된 시크릿 키, 액세스 토큰 만료 시간, 리프레시 토큰 만료 시간 및 발행자로 JwtTokenProvider를 구성합니다.
+     *
+     * @param secretKey          토큰 서명에 사용되는 시크릿 키
+     * @param accessExpireMinutes  액세스 토큰의 만료 시간(분)
+     * @param refreshExpireDays    리프레시 토큰의 만료 시간(일)
+     * @param issuer             토큰 발행자
+     */
+    public JwtTokenProvider(
+            @Value("${jwt.secret-key}") String secretKey,
+            @Value("${jwt.expiration.access}") long accessExpireMinutes,
+            @Value("${jwt.expiration.refresh}") long refreshExpireDays,
+            @Value("${jwt.issuer}") String issuer
+    ) {
+        this.secretKey = secretKey;
+        this.accessExpireMinutes = accessExpireMinutes;
+        this.refreshExpireDays = refreshExpireDays;
+        this.issuer = issuer;
+    }
+
+    /**
+     * 액세스 토큰을 생성합니다.
+     *
+     * @param memberJwtInfo 멤버 정보를 담고 있는 객체
+     * @return 생성된 액세스 토큰
+     */
+    public String createAccessToken(MemberJwtInfo memberJwtInfo) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return Jwts.builder()
+                .signWith(new SecretKeySpec(secretKey.getBytes(), SignatureAlgorithm.HS512.getJcaName()))
+                .setSubject(String.valueOf(memberJwtInfo.memberNo()))
+                .claim("role", memberJwtInfo.role())
+                .setIssuedAt(Date.from(now.atZone(ZoneId.systemDefault()).toInstant()))
+                .setExpiration(Date.from(now.plusMinutes(accessExpireMinutes).atZone(ZoneId.systemDefault()).toInstant()))
+                .compact();
+    }
+
+    /**
+     * 리프레시 토큰을 재생성합니다.
+     *
+     * @param memberJwtInfo 멤버 정보를 담고 있는 객체
+     * @return 생성된 리프레시 토큰
+     */
+    public String createRefreshToken(MemberJwtInfo memberJwtInfo) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return Jwts.builder()
+                .signWith(new SecretKeySpec(secretKey.getBytes(), SignatureAlgorithm.HS512.getJcaName()))
+                .setSubject(String.valueOf(memberJwtInfo.memberNo()))
+                .claim("role", memberJwtInfo.role())
+                .setIssuedAt(Date.from(now.atZone(ZoneId.systemDefault()).toInstant()))
+                .setExpiration(Date.from(now.plusDays(refreshExpireDays).atZone(ZoneId.systemDefault()).toInstant()))
+                .setIssuer(issuer)
+                .compact();
+    }
+
+    /**
+     * 리프레시 토큰을 사용하여 새로운 액세스 토큰을 생성합니다.
+     *
+     * @param refreshToken 리프레시 토큰
+     * @return 새로 생성된 액세스 토큰
+     * @throws RuntimeException 리프레시 토큰이 잘못된 경우 예외가 발생합니다.
+     */
+    public String renewAccessToken(String refreshToken) {
+        // 리프레시 토큰의 유효성 검증
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey.getBytes())
+                .build()
+                .parseClaimsJws(refreshToken)
+                .getBody();
+
+        // 리프레시 토큰이 유효한 경우, 새로운 액세스 토큰 생성
+        if (claims.getIssuer().equals(issuer)) {
+            LocalDateTime now = LocalDateTime.now();
+
+            return Jwts.builder()
+                    .signWith(new SecretKeySpec(secretKey.getBytes(), SignatureAlgorithm.HS512.getJcaName()))
+                    .setSubject(claims.getSubject())
+                    .claim("role", claims.get("role", String.class))
+                    .setIssuedAt(Date.from(now.atZone(ZoneId.systemDefault()).toInstant()))
+                    .setExpiration(Date.from(now.plusMinutes(accessExpireMinutes).atZone(ZoneId.systemDefault()).toInstant()))
+                    .compact();
+        } else {
+            throw new RuntimeException("Invalid refresh token.");
+        }
+    }
+
+    /**
+     * HTTP 요청에서 액세스 토큰을 추출합니다.
+     *
+     * @param request HTTP 요청
+     * @return 추출된 액세스 토큰
+     * @throws IllegalArgumentException Authorization 헤더가 잘못된 경우 예외가 발생합니다.
+     */
+    public String extractAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken == null || bearerToken.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("Invalid Authorization Header");
+        }
+
+        return bearerToken.substring(7); // "Bearer " 이후의 토큰 부분만 추출
+    }
+
+
+    /**
+     * HTTP 요청에서 리프레시 토큰을 추출합니다.
+     *
+     * @param request HTTP 요청
+     * @return 추출된 리프레시 토큰
+     */
+    public String extractRefreshToken(HttpServletRequest request) {
+        return request.getHeader("Refresh-Token");
+    }
+
+
+    /**
+     * 액세스 토큰의 유효성을 검사합니다.
+     *
+     * @param token 검사할 액세스 토큰
+     * @throws InvalidTokenException 토큰이 유효하지 않은 경우 예외가 발생합니다.
+     */
+    public void validateAccessToken(String token) throws InvalidTokenException {
+        Jwts.parserBuilder().setSigningKey(secretKey.getBytes()).build().parseClaimsJws(token);
+    }
+
+    /**
+     * 리프레시 토큰의 유효성을 검사합니다.
+     *
+     * @param token 검사할 리프레시 토큰
+     * @throws InvalidTokenException 토큰이 유효하지 않은 경우 예외가 발생합니다.
+     */
+    public void validateRefreshToken(String token) throws InvalidTokenException {
+        Jwts.parserBuilder().setSigningKey(secretKey.getBytes()).build().parseClaimsJws(token);
+    }
+
+    /**
+     * 액세스 토큰에서 memberNo를 추출합니다.
+     *
+     * @param token 데이터를 가져올 액세스 토큰
+     * @return 추출된 memberNo
+     */
+    public Long getMemberNoFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey.getBytes())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    /**
+     * 액세스 토큰에서 Role을 추출합니다.
+     *
+     * @param token 데이터를 가져올 액세스 토큰
+     * @return 추출된 Role
+     */
+    public Role getRoleFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey.getBytes())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.get("role", Role.class);
+    }
+
+}

--- a/src/main/java/com/runninghi/runninghibackv2/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/runninghi/runninghibackv2/auth/jwt/JwtTokenProvider.java
@@ -107,7 +107,7 @@ public class JwtTokenProvider {
                     .setExpiration(Date.from(now.plusMinutes(accessExpireMinutes).atZone(ZoneId.systemDefault()).toInstant()))
                     .compact();
         } else {
-            throw new RuntimeException("Invalid refresh token.");
+            throw new InvalidTokenException("Invalid refresh token.");
         }
     }
 

--- a/src/main/java/com/runninghi/runninghibackv2/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/runninghi/runninghibackv2/auth/jwt/JwtTokenProvider.java
@@ -1,7 +1,6 @@
 package com.runninghi.runninghibackv2.auth.jwt;
 
 import com.runninghi.runninghibackv2.common.dto.MemberJwtInfo;
-import com.runninghi.runninghibackv2.common.entity.Role;
 import com.runninghi.runninghibackv2.common.exception.custom.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -73,7 +72,7 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .signWith(new SecretKeySpec(secretKey.getBytes(), SignatureAlgorithm.HS512.getJcaName()))
                 .setSubject(String.valueOf(memberJwtInfo.memberNo()))
-                .claim("role", memberJwtInfo.role())
+                .claim("role", memberJwtInfo.role().name())
                 .setIssuedAt(Date.from(now.atZone(ZoneId.systemDefault()).toInstant()))
                 .setExpiration(Date.from(now.plusDays(refreshExpireDays).atZone(ZoneId.systemDefault()).toInstant()))
                 .setIssuer(issuer)
@@ -118,7 +117,7 @@ public class JwtTokenProvider {
      * @return 추출된 액세스 토큰
      * @throws IllegalArgumentException Authorization 헤더가 잘못된 경우 예외가 발생합니다.
      */
-    public String extractAccessToken(HttpServletRequest request) {
+    public String extractAccessTokenFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken == null || bearerToken.startsWith("Bearer ")) {
             throw new IllegalArgumentException("Invalid Authorization Header");
@@ -134,7 +133,7 @@ public class JwtTokenProvider {
      * @param request HTTP 요청
      * @return 추출된 리프레시 토큰
      */
-    public String extractRefreshToken(HttpServletRequest request) {
+    public String extractRefreshTokenFromRequest(HttpServletRequest request) {
         return request.getHeader("Refresh-Token");
     }
 
@@ -176,19 +175,19 @@ public class JwtTokenProvider {
     }
 
     /**
-     * 액세스 토큰에서 Role을 추출합니다.
+     * 액세스 토큰에서 Role을 추출해서 String으로 반환합니다.
      *
      * @param token 데이터를 가져올 액세스 토큰
-     * @return 추출된 Role
+     * @return 추출된 Role의 name()
      */
-    public Role getRoleFromToken(String token) {
+    public String getRoleFromToken(String token) {
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(secretKey.getBytes())
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
 
-        return claims.get("role", Role.class);
+        return claims.get("role", String.class);
     }
 
 }

--- a/src/main/java/com/runninghi/runninghibackv2/common/annotations/HasAccess.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/annotations/HasAccess.java
@@ -1,0 +1,11 @@
+package com.runninghi.runninghibackv2.common.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HasAccess {
+}

--- a/src/main/java/com/runninghi/runninghibackv2/common/dto/MemberJwtInfo.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/dto/MemberJwtInfo.java
@@ -1,0 +1,13 @@
+package com.runninghi.runninghibackv2.common.dto;
+
+import com.runninghi.runninghibackv2.common.entity.Role;
+import com.runninghi.runninghibackv2.member.domain.aggregate.entity.Member;
+
+public record MemberJwtInfo(
+        Long memberNo,
+        Role role
+) {
+    public static MemberJwtInfo from(Member member) {
+        return new MemberJwtInfo(member.getMemberNo(), member.getRole());
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.runninghi.runninghibackv2.common.exception;
 
+import com.runninghi.runninghibackv2.common.exception.custom.InvalidTokenException;
 import com.runninghi.runninghibackv2.common.response.ApiResult;
 import com.runninghi.runninghibackv2.common.response.ErrorCode;
 import jakarta.persistence.EntityNotFoundException;
@@ -37,4 +38,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(ApiResult.error(ErrorCode.BAD_REQUEST));
     }
 
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiResult> handleIllegalStateException() {
+        return ResponseEntity.internalServerError().body(ApiResult.error(ErrorCode.INTER_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<ApiResult> handleInvalidTokenException() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResult.error(ErrorCode.INVALID_TOKEN));
+    }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/common/exception/custom/InvalidTokenException.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/exception/custom/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.runninghi.runninghibackv2.common.exception.custom;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+
+    public InvalidTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilter.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilter.java
@@ -41,7 +41,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             @NonNull FilterChain filterChain
     ) throws IOException, ServletException {
         try {
-            String accessToken = jwtTokenProvider.extractAccessToken(request);
+            String accessToken = jwtTokenProvider.extractAccessTokenFromRequest(request);
             jwtTokenProvider.validateAccessToken(accessToken);
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
@@ -66,7 +66,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
      */
     private void handleExpiredAccessToken(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws IOException, ServletException {
-        String refreshToken = jwtTokenProvider.extractRefreshToken(request);
+        String refreshToken = jwtTokenProvider.extractRefreshTokenFromRequest(request);
         try {
             jwtTokenProvider.validateRefreshToken(refreshToken);
             String newAccessToken = jwtTokenProvider.renewAccessToken(refreshToken);

--- a/src/main/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilter.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilter.java
@@ -1,0 +1,59 @@
+package com.runninghi.runninghibackv2.common.filter;
+
+import com.runninghi.runninghibackv2.auth.jwt.JwtTokenProvider;
+import com.runninghi.runninghibackv2.common.exception.custom.InvalidTokenException;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT 토큰을 처리하는 필터입니다.
+ * 요청에서 JWT 토큰을 추출하고 유효성을 검사한 후 필터 체인을 계속 진행합니다.
+ * 만료된 토큰일 경우 리프레시 토큰을 확인하고 재발급합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * HTTP 요청을 필터링하여 JWT 토큰을 처리하는 메서드입니다.
+     *
+     * @param request  현재 HTTP 요청
+     * @param response 현재 HTTP 응답
+     * @param filterChain 다음 필터 체인
+     * @throws ServletException 서블릿 예외 발생 시
+     * @throws IOException      입출력 예외 발생 시
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            String accessToken = jwtTokenProvider.extractAccessToken(request);
+            jwtTokenProvider.validateAccessToken(accessToken);
+
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            // 리프레시 토큰 확인 및 재발급
+            String refreshToken = jwtTokenProvider.extractRefreshToken(request);
+            jwtTokenProvider.validateRefreshToken(refreshToken);
+            String newAccessToken = jwtTokenProvider.renewAccessToken(refreshToken);
+            response.setHeader("Authorization", "Bearer " + newAccessToken);
+
+            filterChain.doFilter(request, response);
+        } catch (InvalidTokenException e) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Token");
+        } catch (Exception e) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Internal Server Error");
+        }
+    }
+
+}

--- a/src/main/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilter.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -25,35 +26,88 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     /**
-     * HTTP 요청을 필터링하여 JWT 토큰을 처리하는 메서드입니다.
+     * HTTP 요청을 필터링하여 JWT 토큰을 처리합니다.
      *
      * @param request  현재 HTTP 요청
      * @param response 현재 HTTP 응답
      * @param filterChain 다음 필터 체인
-     * @throws ServletException 서블릿 예외 발생 시
      * @throws IOException      입출력 예외 발생 시
+     * @throws ServletException 서블릿 예외 발생 시
      */
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws IOException, ServletException {
         try {
             String accessToken = jwtTokenProvider.extractAccessToken(request);
             jwtTokenProvider.validateAccessToken(accessToken);
-
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
-            // 리프레시 토큰 확인 및 재발급
-            String refreshToken = jwtTokenProvider.extractRefreshToken(request);
+            handleExpiredAccessToken(request, response, filterChain);
+        } catch (InvalidTokenException e) {
+            handleInvalidToken(response);
+        } catch (Exception e) {
+            handleInternalServerError(response);
+        }
+    }
+
+    /**
+     * 만료된 액세스 토큰을 처리합니다.
+     * 리프레시 토큰을 추출하고 유효성을 검사한 후, 새로운 액세스 토큰을 발급하여 응답의 헤더에 설정합니다.
+     * 필터 체인을 계속 진행합니다.
+     *
+     * @param request     현재 HTTP 요청
+     * @param response    현재 HTTP 응답
+     * @param filterChain 다음 필터 체인
+     * @throws IOException      입출력 예외 발생 시
+     * @throws ServletException 서블릿 예외 발생 시
+     */
+    private void handleExpiredAccessToken(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws IOException, ServletException {
+        String refreshToken = jwtTokenProvider.extractRefreshToken(request);
+        try {
             jwtTokenProvider.validateRefreshToken(refreshToken);
             String newAccessToken = jwtTokenProvider.renewAccessToken(refreshToken);
             response.setHeader("Authorization", "Bearer " + newAccessToken);
-
             filterChain.doFilter(request, response);
-        } catch (InvalidTokenException e) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Token");
-        } catch (Exception e) {
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Internal Server Error");
+        } catch (InvalidTokenException ex) {
+            handleUnauthorizedResponse(response);
         }
+    }
+
+    /**
+     * 유효하지 않은 토큰을 처리합니다.
+     * HTTP 응답에 401 상태 코드를 설정하고 메시지를 전송합니다.
+     *
+     * @param response 현재 HTTP 응답
+     * @throws IOException 입출력 예외 발생 시
+     */
+    private void handleInvalidToken(HttpServletResponse response) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Token");
+    }
+
+    /**
+     * 내부 서버 오류를 처리합니다.
+     * HTTP 응답에 500 상태 코드를 설정하고 메시지를 전송합니다.
+     *
+     * @param response 현재 HTTP 응답
+     * @throws IOException 입출력 예외 발생 시
+     */
+    private void handleInternalServerError(HttpServletResponse response) throws IOException {
+        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Internal Server Error");
+    }
+
+    /**
+     * 권한이 없는 응답을 처리합니다.
+     * HTTP 응답에 401 상태 코드를 설정하고 메시지를 전송합니다.
+     *
+     * @param response 현재 HTTP 응답
+     * @throws IOException 입출력 예외 발생 시
+     */
+    private void handleUnauthorizedResponse(HttpServletResponse response) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token expired. Please log in again.");
     }
 
 }

--- a/src/main/java/com/runninghi/runninghibackv2/common/response/ErrorCode.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/response/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     INTER_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"COMMON ERR-500","해당 ID는 존재하지 않습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON ERR-400", "잘못된 요청입니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "COMMON ERR-403", "권한이 없습니다."),
-    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON ERR-404-ENTITY", "해당 ID에 대한 엔티티를 찾을 수 없습니다.")
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON ERR-404-ENTITY", "해당 ID에 대한 엔티티를 찾을 수 없습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "COMMON ERR-401-TOKEN", "유효하지않은 토큰입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/runninghi/runninghibackv2/config/WebConfig.java
+++ b/src/main/java/com/runninghi/runninghibackv2/config/WebConfig.java
@@ -15,6 +15,11 @@ public class WebConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
 
+    /**
+     * JWT 토큰 필터의 설정을 관리하는 빈입니다.
+     *
+     * @return JWT 토큰 필터의 설정 정보를 포함하는 FilterRegistrationBean
+     */
     @Bean
     public FilterRegistrationBean<JwtTokenFilter> jwtTokenFilterConfig() {
         FilterRegistrationBean<JwtTokenFilter> registrationBean = new FilterRegistrationBean<>();

--- a/src/main/java/com/runninghi/runninghibackv2/config/WebConfig.java
+++ b/src/main/java/com/runninghi/runninghibackv2/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.runninghi.runninghibackv2.config;
+
+import com.runninghi.runninghibackv2.auth.jwt.JwtTokenProvider;
+import com.runninghi.runninghibackv2.common.filter.JwtTokenFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@ComponentScan(basePackages = "com.runninghi.runninghibackv2")
+public class WebConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public FilterRegistrationBean<JwtTokenFilter> jwtTokenFilterConfig() {
+        FilterRegistrationBean<JwtTokenFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new JwtTokenFilter(jwtTokenProvider));
+        registrationBean.addUrlPatterns("/api/*");
+        return registrationBean;
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/member/domain/aggregate/entity/Member.java
+++ b/src/main/java/com/runninghi/runninghibackv2/member/domain/aggregate/entity/Member.java
@@ -55,20 +55,24 @@ public class Member extends BaseTimeEntity {
     @Comment("권한")
     private Role role;
 
-    public Member(Builder builder) {
-        this.memberNo = builder.memberNo;
-        this.account = builder.account;
-        this.password = builder.password;
-        this.nickname = builder.nickname;
-        this.kakaoId = builder.kakaoId;
-        this.kakaoName = builder.kakaoName;
-        this.reportCnt = builder.reportCnt;
-        this.isActive = builder.isActive;
-        this.isBlacklisted = builder.isBlacklisted;
-        this.role = builder.role;
+    public Member(MemberBuilder memberBuilder) {
+        this.memberNo = memberBuilder.memberNo;
+        this.account = memberBuilder.account;
+        this.password = memberBuilder.password;
+        this.nickname = memberBuilder.nickname;
+        this.kakaoId = memberBuilder.kakaoId;
+        this.kakaoName = memberBuilder.kakaoName;
+        this.reportCnt = memberBuilder.reportCnt;
+        this.isActive = memberBuilder.isActive;
+        this.isBlacklisted = memberBuilder.isBlacklisted;
+        this.role = memberBuilder.role;
     }
 
-    public static class Builder {
+    public static MemberBuilder builder() {
+        return new MemberBuilder();
+    }
+
+    public static class MemberBuilder {
         private Long memberNo;
         private String account;
         private String password;
@@ -80,52 +84,52 @@ public class Member extends BaseTimeEntity {
         private boolean isBlacklisted;
         private Role role;
 
-        public Builder memberNo(Long memberNo) {
+        public MemberBuilder memberNo(Long memberNo) {
             this.memberNo = memberNo;
             return this;
         }
 
-        public Builder account(String account) {
+        public MemberBuilder account(String account) {
             this.account = account;
             return this;
         }
 
-        public Builder password(String password) {
+        public MemberBuilder password(String password) {
             this.password = password;
             return this;
         }
 
-        public Builder nickname(String nickname) {
+        public MemberBuilder nickname(String nickname) {
             this.nickname = nickname;
             return this;
         }
 
-        public Builder kakaoId(String kakaoId) {
+        public MemberBuilder kakaoId(String kakaoId) {
             this.kakaoId = kakaoId;
             return this;
         }
 
-        public Builder kakaoName(String kakaoName) {
+        public MemberBuilder kakaoName(String kakaoName) {
             this.kakaoName = kakaoName;
             return this;
         }
 
-        public Builder reportCnt(int reportCnt) {
+        public MemberBuilder reportCnt(int reportCnt) {
             this.reportCnt = reportCnt;
             return this;
         }
 
-        public Builder isActive(boolean isActive) {
+        public MemberBuilder isActive(boolean isActive) {
             this.isActive = isActive;
             return this;
         }
 
-        public Builder isBlacklisted(boolean isBlacklisted) {
+        public MemberBuilder isBlacklisted(boolean isBlacklisted) {
             this.isBlacklisted = isBlacklisted;
             return this;
         }
 
-        public Builder role(Role role) {
+        public MemberBuilder role(Role role) {
             this.role = role;
             return this;
         }
@@ -135,6 +139,5 @@ public class Member extends BaseTimeEntity {
         }
 
     }
-
 
 }

--- a/src/main/java/com/runninghi/runninghibackv2/member/domain/aggregate/entity/MemberRefreshToken.java
+++ b/src/main/java/com/runninghi/runninghibackv2/member/domain/aggregate/entity/MemberRefreshToken.java
@@ -1,0 +1,64 @@
+package com.runninghi.runninghibackv2.member.domain.aggregate.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "TBL_REFRESH_TOKEN")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberRefreshToken {
+
+    @Id
+    private Long memberNo;
+
+    @Column
+    private String refreshToken;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_no")
+    private Member member;
+
+    public MemberRefreshToken(MemberRefreshTokenBuilder memberRefreshTokenBuilder) {
+        this.memberNo = memberRefreshTokenBuilder.memberNo;
+        this.refreshToken = memberRefreshTokenBuilder.refreshToken;
+        this.member = memberRefreshTokenBuilder.member;
+    }
+
+    public static MemberRefreshTokenBuilder builder() {
+        return new MemberRefreshTokenBuilder();
+    }
+
+    public static class MemberRefreshTokenBuilder {
+        private Long memberNo;
+        private String refreshToken;
+        private Member member;
+
+        public MemberRefreshTokenBuilder memberNo(Long memberNo) {
+            this.memberNo = memberNo;
+            return this;
+        }
+
+        public MemberRefreshTokenBuilder refreshToken(String refreshToken) {
+            this.refreshToken = refreshToken;
+            return this;
+        }
+
+        public MemberRefreshTokenBuilder member(Member member) {
+            this.member = member;
+            return this;
+        }
+
+        public MemberRefreshToken build() {
+            return new MemberRefreshToken(this);
+        }
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/src/main/java/com/runninghi/runninghibackv2/member/domain/repository/MemberRefreshTokenRepository.java
+++ b/src/main/java/com/runninghi/runninghibackv2/member/domain/repository/MemberRefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package com.runninghi.runninghibackv2.member.domain.repository;
+
+import com.runninghi.runninghibackv2.member.domain.aggregate.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRefreshTokenRepository extends JpaRepository<Member, Long> {
+}

--- a/src/test/java/com/runninghi/runninghibackv2/auto/jwt/JwtTokenProviderTests.java
+++ b/src/test/java/com/runninghi/runninghibackv2/auto/jwt/JwtTokenProviderTests.java
@@ -1,0 +1,140 @@
+package com.runninghi.runninghibackv2.auto.jwt;
+
+import com.runninghi.runninghibackv2.auth.jwt.JwtTokenProvider;
+import com.runninghi.runninghibackv2.common.dto.MemberJwtInfo;
+import com.runninghi.runninghibackv2.common.entity.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class JwtTokenProviderTests {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    private String testAccessToken;
+    private String testRefreshToken;
+
+    @BeforeEach
+    public void setUp() {
+        // 테스트에 사용될 JwtTokenProvider 인스턴스 생성
+        String secretKey = "test_secret_key_12345_12345_12345_12345";
+        long accessExpireMinutes = 30;
+        long refreshExpireDays = 7;
+        String issuer = "test_issuer";
+        jwtTokenProvider = new JwtTokenProvider(secretKey, accessExpireMinutes, refreshExpireDays, issuer);
+
+        MemberJwtInfo memberJwtInfo = new MemberJwtInfo(1L, Role.USER);
+        testAccessToken = jwtTokenProvider.createAccessToken(memberJwtInfo);
+        testRefreshToken = jwtTokenProvider.createRefreshToken(memberJwtInfo);
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 생성 테스트")
+    void testCreateAccessToken() {
+        // 테스트에 사용될 MemberJwtInfo 객체 생성
+        MemberJwtInfo memberJwtInfo = new MemberJwtInfo(1L, Role.USER);
+
+        // 액세스 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(memberJwtInfo);
+
+        // 액세스 토큰이 null이 아닌지 확인
+        assertNotNull(accessToken);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 생성 테스트")
+    void testCreateRefreshToken() {
+        // 테스트에 사용될 MemberJwtInfo 객체 생성
+        MemberJwtInfo memberJwtInfo = new MemberJwtInfo(1L, Role.USER);
+
+        // 리프레시 토큰 생성
+        String refreshToken = jwtTokenProvider.createRefreshToken(memberJwtInfo);
+
+        // 리프레시 토큰이 null이 아닌지 확인
+        assertNotNull(refreshToken);
+    }
+
+
+    @Test
+    @DisplayName("액세스 토큰 유효성 검사 테스트")
+    void testValidateAccessToken() {
+        // 액세스 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(new MemberJwtInfo(1L, Role.USER));
+
+        // 액세스 토큰 유효성 검사
+        assertDoesNotThrow(() -> jwtTokenProvider.validateAccessToken(accessToken));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 유효성 검사 테스트")
+    void testValidateRefreshToken() {
+        // 리프레시 토큰 생성
+        String refreshToken = jwtTokenProvider.createRefreshToken(new MemberJwtInfo(1L, Role.USER));
+
+        // 리프레시 토큰 유효성 검사
+        assertDoesNotThrow(() -> jwtTokenProvider.validateRefreshToken(refreshToken));
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 갱신 테스트")
+    void testRenewAccessToken() {
+        // 리프레시 토큰 생성
+        String refreshToken = jwtTokenProvider.createRefreshToken(new MemberJwtInfo(1L, Role.USER));
+
+        // 액세스 토큰 갱신
+        String renewedAccessToken = jwtTokenProvider.renewAccessToken(refreshToken);
+
+        // 갱신된 액세스 토큰이 null이 아닌지 확인
+        assertNotNull(renewedAccessToken);
+    }
+
+    @Test
+    @DisplayName("액세스 토큰에서 memberNo 추출 테스트")
+    void testGetMemberNoFromToken() {
+        // 액세스 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(new MemberJwtInfo(1L, Role.USER));
+
+        // memberNo 추출
+        Long memberNo = jwtTokenProvider.getMemberNoFromToken(accessToken);
+
+        // 추출된 memberNo가 null이 아닌지 확인
+        assertNotNull(memberNo);
+    }
+
+    @Test
+    @DisplayName("Request에서 토큰 추출 테스트")
+    void testExtractToken() {
+        // 가짜 HttpServletRequest 객체 생성
+        MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+        mockHttpServletRequest.addHeader("Authorization", testAccessToken);
+        mockHttpServletRequest.addHeader("Refresh-Token", testRefreshToken);
+
+        // 액세스 토큰 추출
+        String extractedAccessToken = jwtTokenProvider.extractAccessTokenFromRequest(mockHttpServletRequest);
+
+        // 리프레시 토큰 추출
+        String extractedRefreshToken = jwtTokenProvider.extractRefreshTokenFromRequest(mockHttpServletRequest);
+
+        // 추출된 토큰이 null이 아닌지 확인
+        assertNotNull(extractedAccessToken);
+        assertNotNull(extractedRefreshToken);
+    }
+
+
+    @Test
+    @DisplayName("액세스 토큰에서 Role 추출 테스트")
+    void testGetRoleFromToken() {
+        // Role 추출
+        String role = jwtTokenProvider.getRoleFromToken(testAccessToken);
+
+        // 추출된 Role이 null이 아닌지 확인
+        assertEquals(Role.USER.name(), role);
+    }
+}

--- a/src/test/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilterTests.java
+++ b/src/test/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilterTests.java
@@ -1,0 +1,153 @@
+package com.runninghi.runninghibackv2.common.filter;
+
+import com.runninghi.runninghibackv2.auth.jwt.JwtTokenProvider;
+import com.runninghi.runninghibackv2.common.exception.custom.InvalidTokenException;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class JwtTokenFilterTests {
+
+    @InjectMocks
+    private JwtTokenFilter jwtTokenFilter;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("필터 테스트 : 유효한 액세스 토큰")
+    void testDoFilterInternal_ValidAccessToken() throws Exception {
+        // Mock 객체 생성
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(MockHttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        // 유효한 엑세스 토큰 설정
+        String validAccessToken = "valid_access_token";
+        when(jwtTokenProvider.extractAccessTokenFromRequest(any())).thenReturn(validAccessToken);
+        doNothing().when(jwtTokenProvider).validateAccessToken(anyString());
+
+        // 필터 실행
+        jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+        // FilterChain이 호출되었는지 확인
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("필터 테스트 : 유효하지 않은 액세스 토큰")
+    void testDoFilterInternal_InvalidAccessToken() throws IOException, ServletException {
+        // Mock 객체 생성
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(MockHttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        // 테스트에 필요한 요청 객체 생성 및 설정
+        String invalidAccessToken = "invalid_access_token";
+        when(jwtTokenProvider.extractAccessTokenFromRequest(any())).thenReturn(invalidAccessToken);
+        doThrow(InvalidTokenException.class).when(jwtTokenProvider).validateAccessToken(anyString());
+
+        // doFilterInternal 메소드 호출
+        jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+        // HttpServletResponse의 sendError 메소드가 호출되는지 확인하기 위해 ArgumentCaptor를 생성
+        ArgumentCaptor<Integer> statusCodeCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<String> errorMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(response).sendError(statusCodeCaptor.capture(), errorMessageCaptor.capture());
+
+        // sendError 메소드 호출 시 전달된 상태 코드와 에러 메시지 전달
+        int capturedStatusCode = statusCodeCaptor.getValue();
+        String capturedErrorMessage = errorMessageCaptor.getValue();
+
+        // 상태 코드와 에러 메시지 확인
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, capturedStatusCode);
+        assertEquals("Invalid Token", capturedErrorMessage);
+    }
+
+    @Test
+    @DisplayName("필터 테스트 : 만료된 액세스 토큰")
+    void testDoFilterInternal_ExpiredAccessToken() {
+        // Mock 객체 생성
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(MockHttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        // 만료된 엑세스 토큰을 설정, 예외를 던지도록 설정
+        String expiredAccessToken = "expired_access_token";
+        when(jwtTokenProvider.extractAccessTokenFromRequest(any())).thenReturn(expiredAccessToken);
+        doThrow(ExpiredJwtException.class).when(jwtTokenProvider).validateAccessToken(anyString());
+
+        // 필터 실행, 예외가 발생하지 않는지 확인
+        assertDoesNotThrow(() -> jwtTokenFilter.doFilterInternal(request, response, filterChain));
+    }
+
+    @Test
+    @DisplayName("필터 테스트 : 만료된 리프레시 토큰")
+    void testDoFilterInternal_ExpiredRefreshToken() throws ServletException, IOException {
+        // Mock 객체 생성
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(MockHttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        // 만료된 리프레시 토큰을 설정, 예외를 던지도록 설정
+        String expiredRefreshToken = "expired_refresh_token";
+        when(jwtTokenProvider.extractAccessTokenFromRequest(any())).thenReturn(null);
+        when(jwtTokenProvider.extractRefreshTokenFromRequest(any())).thenReturn(expiredRefreshToken);
+        doThrow(ExpiredJwtException.class).when(jwtTokenProvider).validateRefreshToken(anyString());
+
+        // 필터 실행, FilterChain이 호출되었는지 확인
+        assertDoesNotThrow(() -> jwtTokenFilter.doFilterInternal(request, response, filterChain));
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("필터 테스트 : 서버 에러")
+    void testDoFilterInternal_InternalServerError() throws IOException, ServletException {
+        // Mock 객체 생성
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(MockHttpServletResponse.class);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        // 테스트에 필요한 요청 객체 생성 및 설정
+        String accessToken = "valid_access_token";
+        when(jwtTokenProvider.extractAccessTokenFromRequest(any())).thenReturn(accessToken);
+
+        // validateAccessToken 메소드가 체크된 예외를 던질 때 처리하기 위해 doAnswer 사용
+        doAnswer(invocation -> {
+            throw new ServletException("Error");
+        }).when(jwtTokenProvider).validateAccessToken(anyString());
+
+        // doFilterInternal 메소드 호출
+        jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+        // HttpServletResponse의 sendError 메소드가 호출되는지 확인하기 위해 ArgumentCaptor를 생성
+        ArgumentCaptor<Integer> statusCodeCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<String> errorMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(response).sendError(statusCodeCaptor.capture(), errorMessageCaptor.capture());
+
+        // sendError 메소드 호출 시 전달된 상태 코드와 에러 메시지 전달
+        int capturedStatusCode = statusCodeCaptor.getValue();
+        String capturedErrorMessage = errorMessageCaptor.getValue();
+
+        // 상태 코드, 에러 메시지 확인
+        assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, capturedStatusCode);
+        assertEquals("Internal Server Error", capturedErrorMessage);
+    }
+
+}

--- a/src/test/java/com/runninghi/runninghibackv2/feedback/application/service/FeedbackServiceTests.java
+++ b/src/test/java/com/runninghi/runninghibackv2/feedback/application/service/FeedbackServiceTests.java
@@ -56,17 +56,17 @@ class FeedbackServiceTests {
     @BeforeEach
     void setup() {
         // 테스트 멤버 생성 및 저장
-        testMember1 = new Member.Builder()
+        testMember1 = new Member.MemberBuilder()
                 .nickname("testUser1")
                 .role(Role.USER)
                 .build();
 
-        testMember2 = new Member.Builder()
+        testMember2 = new Member.MemberBuilder()
                 .nickname("testUser2")
                 .role(Role.USER)
                 .build();
 
-        testAdmin = new Member.Builder()
+        testAdmin = new Member.MemberBuilder()
                 .nickname("testUser2")
                 .role(Role.ADMIN)
                 .build();


### PR DESCRIPTION
## 📌 관련 이슈 #63

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #63 

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- RefreshToken을 DB에 저장할 수 있도록 entity와 repository 생성
- AuthAspect : 권한을 확인하는 aop, 사용자 정의 어노테이션 설정
- Jwt Provider : jwt 토큰을 관리하는 provider 
- Jwt Filter : 요청이 들어올 때 jwt Token을 확인하는 filter 설정
- Jwt Provider 테스트 코드 
- Jwt Filter 테스트 코드

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
대부분의 러닝 어플리케이션이 로그인을 필수로 해야하길래 일단 jwt 토큰을 확인하는 필터를 "/api/*"로 해뒀습니다!

✨ **@ HasAccess** 어노테이션에 대한 테스트는 아직 진행 못했습니다. 확인되면 알려드릴테니 아직은 쓰지말아주세요!

exception에 custom 폴더를 만들었습니다. 적절한 exception이 없다면 커스텀 exception을 해당 폴더 안에 만들고, GlobalExceptionHandler에 등록해주시면 됩니다. 

<br>
<br>

