### PR TITLE
[#94] 2024.03.21 hotfix : 임시로 필터 경로 바꿈, filter의 Component 어노테이션 삭제

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilter.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilter.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -19,7 +18,6 @@ import java.io.IOException;
  * 요청에서 JWT 토큰을 추출하고 유효성을 검사한 후 필터 체인을 계속 진행합니다.
  * 만료된 토큰일 경우 리프레시 토큰을 확인하고 재발급합니다.
  */
-@Component
 @RequiredArgsConstructor
 public class JwtTokenFilter extends OncePerRequestFilter {
 

--- a/src/main/java/com/runninghi/runninghibackv2/config/WebConfig.java
+++ b/src/main/java/com/runninghi/runninghibackv2/config/WebConfig.java
@@ -19,7 +19,7 @@ public class WebConfig {
     public FilterRegistrationBean<JwtTokenFilter> jwtTokenFilterConfig() {
         FilterRegistrationBean<JwtTokenFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new JwtTokenFilter(jwtTokenProvider));
-        registrationBean.addUrlPatterns("/api/*");
+        registrationBean.addUrlPatterns("/api/v3/*");
         return registrationBean;
     }
 }


### PR DESCRIPTION
## 📌 #94

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
* closed #94

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- 모든 요청에 대해 Internal Server Error가 발생하는 Bug 수정

🪄  JwtTokenFilter class의 @ Component 삭제
🪄  WebConfig의 필터 적용 경로를 임시로 설정

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

![image](https://github.com/cca-ffodregamdi/running-hi-back-v2/assets/61495627/a886f18a-e9e2-4664-999c-79700ac6968a)

Fix 후 요청이 제대로 들어가는 것 확인했습니다!

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

Filter class에 ```@Component``` 어노테이션을 달 경우, spring 자동으로 모든 경로에 대해 해당 필터를 적용하게 됩니다. 
이 설정은 FilterRegistrationBean을 통한 명시적 등록을 무시하고 적용된다고 합니다! 😂 
생각해보니 webconfig에서 filter를 등록해주는데 filter 클래스에 ```@Component```를 다는건 정말 이상하네요...🥲

<br>
<br>

**PR Title 형식 예시**

```
[Feature - Feb 1st, 2024]{USER} 엔티티 설계
```
