### PR TITLE
[Refactoring - Apr 2nd, 2024]{Common} ApiResult 제네릭으로 변경

### DIFF
--- a/src/main/generated/com/runninghi/runninghibackv2/member/domain/aggregate/entity/QMember.java
+++ b/src/main/generated/com/runninghi/runninghibackv2/member/domain/aggregate/entity/QMember.java
@@ -26,6 +26,10 @@ public class QMember extends EntityPathBase<Member> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
 
+    public final DateTimePath<java.time.LocalDateTime> deactivateDate = createDateTime("deactivateDate", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> distanceToNextLevel = createNumber("distanceToNextLevel", Integer.class);
+
     public final BooleanPath isActive = createBoolean("isActive");
 
     public final BooleanPath isBlacklisted = createBoolean("isBlacklisted");
@@ -33,6 +37,8 @@ public class QMember extends EntityPathBase<Member> {
     public final StringPath kakaoId = createString("kakaoId");
 
     public final StringPath kakaoName = createString("kakaoName");
+
+    public final NumberPath<Integer> level = createNumber("level", Integer.class);
 
     public final NumberPath<Long> memberNo = createNumber("memberNo", Long.class);
 
@@ -45,6 +51,10 @@ public class QMember extends EntityPathBase<Member> {
     public final NumberPath<Integer> reportCnt = createNumber("reportCnt", Integer.class);
 
     public final EnumPath<com.runninghi.runninghibackv2.common.entity.Role> role = createEnum("role", com.runninghi.runninghibackv2.common.entity.Role.class);
+
+    public final NumberPath<Double> totalDistance = createNumber("totalDistance", Double.class);
+
+    public final NumberPath<Long> totalKcal = createNumber("totalKcal", Long.class);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updateDate = _super.updateDate;

--- a/src/main/java/com/runninghi/runninghibackv2/common/response/ApiResult.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/response/ApiResult.java
@@ -1,23 +1,29 @@
 package com.runninghi.runninghibackv2.common.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 
-public record ApiResult(
+public record ApiResult<T>(
+        @Schema(description = "응답 시간", example = "2024-03-27T14:20:52.026425")
         LocalDateTime timeStamp,
+        @Schema(description = "응답 상태", example = "OK")
         HttpStatus status,
+        @Schema(description = "응답 메시지", example = "성공 응답 메시지 예시")
         String message,
-        Object data
+        @Schema(description = "응답 데이터")
+        T data
 ) {
 
-    public static ApiResult success(String message, Object data) {
-        return new ApiResult(LocalDateTime.now(), HttpStatus.OK, message, data);
+    public static <T> ApiResult<T> success(String message, T data) {
+        return new ApiResult<>(LocalDateTime.now(), HttpStatus.OK, message, data);
     }
 
-    public static ApiResult error(ErrorCode errorCode) {
+    public static <T> ApiResult<T> error(ErrorCode errorCode) {
         String errorMessage = errorCode.getCode() + " : " + errorCode.getMessage();
-        return new ApiResult(LocalDateTime.now(), errorCode.getStatus(), errorMessage, null);
+        return new ApiResult<>(LocalDateTime.now(), errorCode.getStatus(), errorMessage, null);
     }
 
 }
+

--- a/src/main/java/com/runninghi/runninghibackv2/config/SwaggerConfig.java
+++ b/src/main/java/com/runninghi/runninghibackv2/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package com.runninghi.runninghibackv2.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,7 +13,13 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components().addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                        .name("Authorization")
+                        .in(SecurityScheme.In.HEADER)))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"))
                 .info(new Info()
                         .title("러닝하이 v2")
                         .description("Swagger UI for RunningHi Version 2")

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/controller/FeedbackController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/controller/FeedbackController.java
@@ -87,7 +87,7 @@ public class FeedbackController {
 
         GetFeedbackResponse response = feedbackService.getFeedbackByAdmin(feedbackNo, memberNo);
 
-        return ResponseEntity.ok(ApiResult.success("", response));
+        return ResponseEntity.ok(ApiResult.success("피드백 조회 성공 : 관리자", response));
     }
 
     @HasAccess

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/controller/FeedbackController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/controller/FeedbackController.java
@@ -8,6 +8,8 @@ import com.runninghi.runninghibackv2.feedback.application.dto.request.UpdateFeed
 import com.runninghi.runninghibackv2.feedback.application.dto.request.UpdateFeedbackRequest;
 import com.runninghi.runninghibackv2.feedback.application.dto.response.*;
 import com.runninghi.runninghibackv2.feedback.application.service.FeedbackService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -22,14 +24,15 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "피드백 API", description = "피드백/문의사항 관련 API")
 public class FeedbackController {
 
     private final FeedbackService feedbackService;
     private final JwtTokenProvider jwtTokenProvider;
 
-    // 피드백 작성
     @PostMapping("/api/v1/feedbacks")
-    public ResponseEntity<ApiResult> createFeedback(
+    @Operation(summary = "피드백 작성", description = "피드백/문의사항을 작성합니다.")
+    public ResponseEntity<ApiResult<CreateFeedbackResponse>> createFeedback(
             @RequestHeader(value = "Authorization") String token,
             @RequestBody CreateFeedbackRequest request
     ) throws BadRequestException {
@@ -41,9 +44,9 @@ public class FeedbackController {
         return ResponseEntity.ok(ApiResult.success("피드백 저장 성공", response));
     }
 
-    // 피드백 상세 조회
     @GetMapping("/api/v1/feedbacks/{feedbackNo}")
-    public ResponseEntity<ApiResult> getFeedback(
+    @Operation(summary = "피드백 상세 조회", description = "특정 피드백/문의사항을 조회합니다.")
+    public ResponseEntity<ApiResult<GetFeedbackResponse>> getFeedback(
             @RequestHeader(value = "Authorization") String token,
             @PathVariable("feedbackNo") Long feedbackNo
     ) {
@@ -55,9 +58,9 @@ public class FeedbackController {
         return ResponseEntity.ok(ApiResult.success("피드백 조회 성공", response));
     }
 
-    // 전체 피드백 리스트 조회
     @GetMapping("/api/v1/feedbacks")
-    public ResponseEntity<ApiResult> getFeedbackScroll(
+    @Operation(summary = "전체 피드백 리스트 조회", description = "전체 피드백/문의사항 리스트를 조회합니다.")
+    public ResponseEntity<ApiResult<Page<GetFeedbackResponse>>> getFeedbackScroll(
             @RequestHeader(value = "Authorization") String token,
             @RequestParam(defaultValue = "0") @PositiveOrZero int page,
             @RequestParam(defaultValue = "10") @Positive int size,
@@ -73,10 +76,10 @@ public class FeedbackController {
         return ResponseEntity.ok(ApiResult.success("피드백 페이지 조회 성공", response));
     }
 
-    // 피드백 상세 조회 : 관리자
     @HasAccess
     @GetMapping("/api/v1/feedbacks/admin/{feedbackNo}")
-    public ResponseEntity<ApiResult> getFeedbackByAdmin(
+    @Operation(summary = "피드백 상세 조회 (관리자)", description = "특정 피드백/문의사항을 관리자가 조회합니다.")
+    public ResponseEntity<ApiResult<GetFeedbackResponse>> getFeedbackByAdmin(
             @RequestHeader(value = "Authorization") String token,
             @PathVariable("feedbackNo") Long feedbackNo) {
 
@@ -84,14 +87,13 @@ public class FeedbackController {
 
         GetFeedbackResponse response = feedbackService.getFeedbackByAdmin(feedbackNo, memberNo);
 
-        return ResponseEntity.ok(ApiResult.success("피드백 조회 성공 : 관리자", response));
+        return ResponseEntity.ok(ApiResult.success("", response));
     }
 
-
-    // 전체 피드백 리스트 조회 : 관리자
     @HasAccess
     @GetMapping("/api/v1/feedbacks/admin")
-    public ResponseEntity<ApiResult> getFeedbackScrollByAdmin(
+    @Operation(summary = "전체 피드백 리스트 조회 (관리자)", description = "관리자가 전체 피드백/문의사항 리스트를 조회합니다.")
+    public ResponseEntity<ApiResult<Page<GetFeedbackResponse>>> getFeedbackScrollByAdmin(
             @RequestHeader(value = "Authorization") String token,
             @RequestParam(defaultValue = "0") @PositiveOrZero int page,
             @RequestParam(defaultValue = "10") @Positive int size,
@@ -107,9 +109,9 @@ public class FeedbackController {
         return ResponseEntity.ok(ApiResult.success("피드백 리스트 조회 성공 : 관리자", response));
     }
 
-    // 피드백 삭제
     @DeleteMapping("/api/v1/feedbacks/{feedbackNo}")
-    public ResponseEntity<ApiResult> deleteFeedback(
+    @Operation(summary = "피드백 삭제", description = "특정 피드백/문의사항을 삭제합니다.")
+    public ResponseEntity<ApiResult<DeleteFeedbackResponse>> deleteFeedback(
             @RequestHeader(value = "Authorization") String token,
             @PathVariable("feedbackNo") Long feedbackNo
     ) {
@@ -121,9 +123,9 @@ public class FeedbackController {
         return ResponseEntity.ok(ApiResult.success("피드백 삭제 성공", response));
     }
 
-    // 피드백 수정
     @PutMapping("/api/v1/feedbacks/{feedbackNo}")
-    public ResponseEntity<ApiResult> updateFeedback(
+    @Operation(summary = "피드백 수정", description = "특정 피드백/문의사항을 수정합니다.")
+    public ResponseEntity<ApiResult<UpdateFeedbackResponse>> updateFeedback(
             @RequestHeader(value = "Authorization") String token,
             @PathVariable("feedbackNo") Long feedbackNo,
             @RequestBody UpdateFeedbackRequest request
@@ -136,10 +138,10 @@ public class FeedbackController {
         return ResponseEntity.ok(ApiResult.success("피드백 수정 성공", response));
     }
 
-    // 피드백 답변 작성 및 수정 : 관리자
     @HasAccess
     @PutMapping("/api/v1/feedbacks/admin/{feedbackNo}")
-    public ResponseEntity<ApiResult> updateFeedbackReply(
+    @Operation(summary = "피드백 답변 작성/수정 (관리자)", description = "관리자가 피드백 답변을 작성 또는 수정합니다.")
+    public ResponseEntity<ApiResult<UpdateFeedbackReplyResponse>> updateFeedbackReply(
             @RequestHeader(value = "Authorization") String token,
             @PathVariable("feedbackNo") Long feedbackNo,
             @RequestBody UpdateFeedbackReplyRequest request

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/request/CreateFeedbackRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/request/CreateFeedbackRequest.java
@@ -1,8 +1,14 @@
 package com.runninghi.runninghibackv2.feedback.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "피드백 작성 요청")
 public record CreateFeedbackRequest(
+        @Schema(description = "피드백 제목", example = "서비스 개선 요청 / 문의사항")
         String title,
+        @Schema(description = "피드백 제목", example = "서비스 이용 중 발견한 문제 / 문의사항에 대한 상세 설명")
         String content,
+        @Schema(description = "피드백 카테고리", example = "0")
         int category
 ) {
 }

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/request/DeleteFeedbackRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/request/DeleteFeedbackRequest.java
@@ -1,6 +1,0 @@
-package com.runninghi.runninghibackv2.feedback.application.dto.request;
-
-public record DeleteFeedbackRequest(
-        Long feedbackNo
-) {
-}

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/request/GetFeedbackRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/request/GetFeedbackRequest.java
@@ -1,6 +1,0 @@
-package com.runninghi.runninghibackv2.feedback.application.dto.request;
-
-public record GetFeedbackRequest(
-        Long feedbackNo
-) {
-}

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/request/UpdateFeedbackReplyRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/request/UpdateFeedbackReplyRequest.java
@@ -1,6 +1,10 @@
 package com.runninghi.runninghibackv2.feedback.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "피드백 답변 작성 요청")
 public record UpdateFeedbackReplyRequest(
+        @Schema(description = "피드백 / 문의사항에 대한 답변", example = "고객님의 문의사항에 대해 답변드립니다.")
         String content
 ) {
 }

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/request/UpdateFeedbackRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/request/UpdateFeedbackRequest.java
@@ -1,8 +1,14 @@
 package com.runninghi.runninghibackv2.feedback.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "피드백 수정 요청")
 public record UpdateFeedbackRequest(
+        @Schema(description = "제목", example = "서비스 개선 요청 / 문의사항 수정")
         String title,
+        @Schema(description = "내용", example = "서비스 이용 중 발견한 문제 / 문의사항에 대한 상세 설명 수정")
         String content,
+        @Schema(description = "카테고리", example = "3")
         int category
 ) {
 }

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/response/CreateFeedbackResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/response/CreateFeedbackResponse.java
@@ -1,10 +1,14 @@
 package com.runninghi.runninghibackv2.feedback.application.dto.response;
 
 import com.runninghi.runninghibackv2.feedback.domain.aggregate.entity.Feedback;
-
+import io.swagger.v3.oas.annotations.media.Schema;
+@Schema(description = "피드백 작성")
 public record CreateFeedbackResponse(
+        @Schema(description = "피드백 Id", example = "1")
         Long feedbackNo,
+        @Schema(description = "제목", example = "서비스 개선 요청 / 문의사항")
         String title,
+        @Schema(description = "내용", example = "서비스 이용 중 발견한 문제 / 문의사항에 대한 상세 설명")
         String content
 ) {
     public static CreateFeedbackResponse from(Feedback feedback) {

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/response/DeleteFeedbackResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/response/DeleteFeedbackResponse.java
@@ -1,6 +1,10 @@
 package com.runninghi.runninghibackv2.feedback.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "피드백 삭제 응답")
 public record DeleteFeedbackResponse(
+        @Schema(description = "삭제된 Feedback Id", example = "1")
         Long feedbackNo
 ) {
     public static DeleteFeedbackResponse from(Long feedbackNo) {

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/response/GetFeedbackResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/response/GetFeedbackResponse.java
@@ -2,17 +2,27 @@ package com.runninghi.runninghibackv2.feedback.application.dto.response;
 
 import com.runninghi.runninghibackv2.feedback.domain.aggregate.entity.Feedback;
 import com.runninghi.runninghibackv2.feedback.domain.aggregate.entity.FeedbackCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "피드백 조회")
 public record GetFeedbackResponse(
+        @Schema(description = "제목", example = "서비스 개선 요청 / 문의사항")
         String title,
+        @Schema(description = "내용", example = "서비스 이용 중 발견한 문제 / 문의사항에 대한 상세 설명 수정")
         String content,
+        @Schema(description = "카테고리", example = "INQUIRY")
         FeedbackCategory category,
+        @Schema(description = "작성일시", example = "2024-03-27T13:23:12")
         LocalDateTime createDate,
+        @Schema(description = "수정일시", example = "2024-03-28T12:23:12")
         LocalDateTime updateDate,
+        @Schema(description = "답변 여부", example = "true")
         boolean hasReply,
+        @Schema(description = "피드백 / 문의사항에 대한 답변", example = "고객님의 문의사항에 대해 답변드립니다.")
         String reply,
+        @Schema(description = "작성자 닉네임", example = "러너 96541953")
         String nickname
 ) {
     public static GetFeedbackResponse from(Feedback feedback) {

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/response/UpdateFeedbackReplyResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/response/UpdateFeedbackReplyResponse.java
@@ -2,17 +2,27 @@ package com.runninghi.runninghibackv2.feedback.application.dto.response;
 
 import com.runninghi.runninghibackv2.feedback.domain.aggregate.entity.Feedback;
 import com.runninghi.runninghibackv2.feedback.domain.aggregate.entity.FeedbackCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "피드백 답변 응답")
 public record UpdateFeedbackReplyResponse(
+        @Schema(description = "제목", example = "서비스 개선 요청 / 문의사항")
         String title,
+        @Schema(description = "내용", example = "서비스 이용 중 발견한 문제 / 문의사항에 대한 상세 설명")
         String content,
+        @Schema(description = "카테고리", example = "INQUIRY")
         FeedbackCategory category,
+        @Schema(description = "작성일시", example = "2024-03-27T13:23:12")
         LocalDateTime createDate,
+        @Schema(description = "수정일시", example = "2024-03-27T13:23:12")
         LocalDateTime updateDate,
+        @Schema(description = "답변 여부", example = "true")
         boolean hasReply,
+        @Schema(description = "피드백 / 문의사항에 대한 답변", example = "고객님의 문의사항에 대해 답변드립니다.")
         String reply,
+        @Schema(description = "작성자 닉네임", example = "러너 96541953")
         String nickname
 ) {
     public static UpdateFeedbackReplyResponse from(Feedback feedback) {

--- a/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/response/UpdateFeedbackResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/feedback/application/dto/response/UpdateFeedbackResponse.java
@@ -1,11 +1,17 @@
 package com.runninghi.runninghibackv2.feedback.application.dto.response;
 
 import com.runninghi.runninghibackv2.feedback.domain.aggregate.entity.Feedback;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "피드백 수정 응답")
 public record UpdateFeedbackResponse(
+        @Schema(description = "피드백 Id", example = "1")
         Long feedbackNo,
+        @Schema(description = "제목", example = "서비스 개선 요청 / 문의사항 수정")
         String title,
+        @Schema(description = "내용", example = "서비스 이용 중 발견한 문제 / 문의사항에 대한 상세 설명 수정")
         String content,
+        @Schema(description = "카테고리", example = "ROUTEERROR")
         String category
 ) {
     public static UpdateFeedbackResponse from(Feedback feedback) {


### PR DESCRIPTION
## 📌 #167

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

- closed #167

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- 안정성과 Swagger 설정을 위해 ApiResut의 Object 타입을 제네릭으로 변경
- SwaggerConfig에 토큰 설정 추가

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

**Swagger에서 API 테스트를 진행했을 때 결과**
<img width="1264" alt="image" src="https://github.com/cca-ffodregamdi/running-hi-back-v2/assets/61495627/0b7e69a4-dcfd-4e22-bc27-3a1273e5b06c">

<br>

**Token값이 유효하지않을 때 결과**
<img width="1264" alt="image" src="https://github.com/cca-ffodregamdi/running-hi-back-v2/assets/61495627/1d12dfc3-3835-427b-b481-b11dd490958b">



## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
- 예시가 있으면 좋을 것 같아서 Feedback Domain의 Controller와 dto들에 Schema 적용을 해두었습니다! 
- Swagger에 토큰 설정을 추가했습니다. 
  local에서 테스트를 하신다면, 먼저 회원가입을 진행한 후, 생성된 액세스 토큰을 Swagger UI 우측 상단 Authorize의 value에 **Bearer를 제외하고** 입력해주세요! 
액세스 토큰이 유효하다면 `Authorization 헤더`에 값을 입력할 필요없이, 각 API의 `Try it out` -> `Execute`를 클릭하는 것으로 API 테스트를 진행할 수 있습니다. 
  - 액세스 토큰이 유효하지않다면 `COMMON ERR-401-TOKEN`에러가 발생하고, 위 스크린샷과 같은 예외처리 응답값을 확인하실 수 있습니다ㅎ


액세스 토큰을 입력하는 과정이 번거로워서 좀 더 쉽게 할 방법이 없나 알아보고있습니다...🥲 