### PR TITLE
[Feature - May 2nd, 2024] - {ALL} 테스트용 유저&어드민 생성, 더미 데이터

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/service/KakaoOauthService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/KakaoOauthService.java
@@ -164,7 +164,7 @@ public class KakaoOauthService {
                 .isActive(true)
                 .isBlacklisted(false)
                 .role(Role.USER)
-                .distanceToNextLevel(0)
+                .distanceToNextLevel(10)
                 .totalKcal(0.0)
                 .totalDistance(0.0)
                 .level(0)

--- a/src/main/java/com/runninghi/runninghibackv2/common/dummy/TestData.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/dummy/TestData.java
@@ -1,0 +1,378 @@
+package com.runninghi.runninghibackv2.common.dummy;
+
+import com.runninghi.runninghibackv2.common.response.ApiResult;
+import com.runninghi.runninghibackv2.domain.entity.*;
+import com.runninghi.runninghibackv2.domain.entity.vo.BookmarkId;
+import com.runninghi.runninghibackv2.domain.entity.vo.GpxDataVO;
+import com.runninghi.runninghibackv2.domain.entity.vo.PostKeywordId;
+import com.runninghi.runninghibackv2.domain.enumtype.FeedbackCategory;
+import com.runninghi.runninghibackv2.domain.enumtype.ProcessingStatus;
+import com.runninghi.runninghibackv2.domain.enumtype.ReportCategory;
+import com.runninghi.runninghibackv2.domain.enumtype.Role;
+import com.runninghi.runninghibackv2.domain.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TestData {
+
+    private final MemberRepository memberRepository;
+    private final AlarmRepository alarmRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final FeedbackRepository feedbackRepository;
+    private final PostKeywordRepository postKeywordRepository;
+    private final PostReportRepository postReportRepository;
+    private final PostRepository postRepository;
+    private final ReplyReportRepository replyReportRepository;
+    private final ReplyRepository replyRepository;
+    private final KeywordRepository keywordRepository;
+
+    @PostMapping("/test-data")
+    public ResponseEntity<ApiResult> setUp() {
+        List<Member> members = new ArrayList<>();
+        LocalDateTime dateTime = LocalDateTime.now().minusDays(31);
+
+        Member member1 = Member.builder()
+                .deactivateDate(dateTime)
+                .alarmConsent(true)
+                .kakaoName("kakaoName")
+                .level(1)
+                .isActive(false)
+                .totalDistance(1000)
+                .build();
+        members.add(member1);
+
+        Member member2 = Member.builder()
+                .deactivateDate(LocalDateTime.now().minusDays(15))
+                .alarmConsent(true)
+                .kakaoName("nyam")
+                .level(1)
+                .isActive(true)
+                .totalDistance(1000)
+                .build();
+        members.add(member2);
+
+        memberRepository.saveAllAndFlush(members);
+
+
+        List<Alarm> alarms = new ArrayList<>();
+
+        Alarm alarm1 = Alarm.builder()
+                .member(member1)
+                .title("테스트 알림 1")
+                .content("테스트 알림 내용 1")
+                .isRead(false)
+                .createDate(LocalDateTime.now().minusDays(1))
+                .build();
+        alarms.add(alarm1);
+
+        Alarm alarm2 = Alarm.builder()
+                .member(member1)
+                .title("테스트 알림 2")
+                .content("테스트 알림 내용 2")
+                .isRead(true)
+                .createDate(LocalDateTime.now().minusDays(2))
+                .readDate(LocalDateTime.now().minusDays(1))
+                .build();
+        alarms.add(alarm2);
+
+        Alarm alarm3 = Alarm.builder()
+                .member(member2)
+                .title("테스트 알림 3")
+                .content("테스트 알림 내용 3 : 남아있는 테스트 알림입니다.")
+                .isRead(true)
+                .createDate(LocalDateTime.now().minusDays(2))
+                .readDate(LocalDateTime.now().minusDays(1))
+                .build();
+        alarms.add(alarm3);
+
+        alarmRepository.saveAllAndFlush(alarms);
+
+        List<Post> posts = new ArrayList<>();
+
+        Post post1 = Post.builder()
+                .member(member1)
+                .postTitle("첫 번째 게시글")
+                .postContent("첫 번째 게시글 내용입니다.")
+                .role(Role.USER)
+                .locationName("서울")
+                .gpxDataVO(new GpxDataVO(37.1234f, 127.5678f, 37.9876f, 126.5432f, 10.5f, 3600f, 200f, 5f, 6f, 3f))
+                .build();
+        posts.add(post1);
+
+        // 남아있는 게시물
+        Post post2 = Post.builder()
+                .member(member2)
+                .postTitle("두 번째 게시글")
+                .postContent("두 번째 게시글 내용입니다. : 남아있는 게시글 입니다.")
+                .role(Role.ADMIN)
+                .locationName("부산")
+                .gpxDataVO(new GpxDataVO(36.9876f, 126.5432f, 36.1234f, 127.5678f, 12.3f, 4500f, 250f, 4f, 5f, 2f))
+                .build();
+        posts.add(post2);
+
+        Post post3 = Post.builder()
+                .member(member1)
+                .postTitle("세 번째 게시글")
+                .postContent("세 번째 게시글 내용입니다.")
+                .role(Role.USER)
+                .locationName("대구")
+                .gpxDataVO(new GpxDataVO(35.6789f, 128.9876f, 35.4321f, 129.8765f, 8.7f, 3000f, 180f, 6f, 7f, 4f))
+                .build();
+        posts.add(post3);
+
+        postRepository.saveAllAndFlush(posts);
+
+
+        List<Bookmark> bookmarks = new ArrayList<>();
+
+        Bookmark bookmark1 = new Bookmark.BookmarkBuilder()
+                .bookmarkId(new BookmarkId(1L, 1L))
+                .member(member1)
+                .post(post1)
+                .build();
+        bookmarks.add(bookmark1);
+
+        Bookmark bookmark2 = new Bookmark.BookmarkBuilder()
+                .bookmarkId(new BookmarkId(1L, 2L))
+                .member(member1)
+                .post(post2)
+                .build();
+        bookmarks.add(bookmark2);
+
+        Bookmark bookmark3 = new Bookmark.BookmarkBuilder()
+                .bookmarkId(new BookmarkId(2L, 3L))
+                .member(member2)
+                .post(post3)
+                .build();
+        bookmarks.add(bookmark3);
+
+        // 남아있는 북마크
+        Bookmark bookmark4 = new Bookmark.BookmarkBuilder()
+                .bookmarkId(new BookmarkId(2L, 2L))
+                .member(member2)
+                .post(post2)
+                .build();
+        bookmarks.add(bookmark4);
+
+        bookmarkRepository.saveAllAndFlush(bookmarks);
+
+
+        List<Reply> replies = new ArrayList<>();
+
+        Reply reply1 = Reply.builder()
+                .writer(member1)
+                .post(post1)
+                .replyContent("첫 번째 댓글 내용입니다. : member1")
+                .reportedCount(0)
+                .reportStatus(null)
+                .isDeleted(false)
+                .build();
+        replies.add(reply1);
+
+        // 남아있는 댓글
+        Reply reply2 = Reply.builder()
+                .writer(member2)
+                .post(post2)
+                .replyContent("두 번째 댓글 내용입니다. : 남아있는 댓글입니다.")
+                .reportedCount(0)
+                .reportStatus(null)
+                .isDeleted(false)
+                .build();
+        replies.add(reply2);
+
+        Reply reply3 = Reply.builder()
+                .writer(member2)
+                .post(post1)
+                .replyContent("첫 번째 댓글 내용입니다. : member2")
+                .reportedCount(0)
+                .reportStatus(null)
+                .isDeleted(false)
+                .build();
+        replies.add(reply3);
+
+        Reply parentReply = Reply.builder()
+                .writer(member1)
+                .post(post2)
+                .replyContent("부모 댓글입니다.")
+                .reportedCount(0)
+                .reportStatus(null)
+                .isDeleted(false)
+                .build();
+        replies.add(parentReply);
+
+        Reply childReply1 = Reply.builder()
+                .writer(member2)
+                .post(post2)
+                .replyContent("자식 댓글입니다.")
+                .reportedCount(0)
+                .reportStatus(null)
+                .isDeleted(false)
+                .parent(parentReply)
+                .build();
+        replies.add(childReply1);
+
+        Reply childReply2 = Reply.builder()
+                .writer(member1)
+                .post(post2)
+                .replyContent("또 다른 자식 댓글입니다.")
+                .reportedCount(0)
+                .reportStatus(null)
+                .isDeleted(false)
+                .parent(parentReply)
+                .build();
+        replies.add(childReply2);
+
+        replyRepository.saveAllAndFlush(replies);
+
+
+        List<ReplyReport> replyReports = new ArrayList<>();
+
+        // 남아있는 댓글 신고
+        ReplyReport report1 = ReplyReport.builder()
+                .category(ReportCategory.SPAM)
+                .content("스팸 댓글입니다.")
+                .status(ProcessingStatus.INPROGRESS)
+                .reporter(member1)
+                .reportedReply(reply2)
+                .replyContent(reply2.getReplyContent())
+                .isReplyDeleted(false)
+                .build();
+        replyReports.add(report1);
+
+        ReplyReport report2 = ReplyReport.builder()
+                .category(ReportCategory.ILLEGALITY)
+                .content("부적절한 내용이 포함된 댓글입니다.")
+                .status(ProcessingStatus.INPROGRESS)
+                .reporter(member2)
+                .reportedReply(reply1)
+                .replyContent(reply1.getReplyContent())
+                .isReplyDeleted(false)
+                .build();
+        replyReports.add(report2);
+
+        ReplyReport report3 = ReplyReport.builder()
+                .category(ReportCategory.ILLEGALITY)
+                .content("부적절한 내용이 포함된 댓글입니다.")
+                .status(ProcessingStatus.INPROGRESS)
+                .reporter(member2)
+                .reportedReply(childReply1)
+                .replyContent(childReply1.getReplyContent())
+                .isReplyDeleted(false)
+                .build();
+        replyReports.add(report3);
+
+        replyReportRepository.saveAllAndFlush(replyReports);
+
+
+        List<PostReport> postReports = new ArrayList<>();
+
+        PostReport postReport1 = PostReport.builder()
+                .category(ReportCategory.SPAM)
+                .content("스팸 게시글입니다.")
+                .status(ProcessingStatus.INPROGRESS)
+                .reporter(member2)
+                .reportedPost(post1)
+                .postContent(post1.getPostContent())
+                .isPostDeleted(false)
+                .build();
+        postReports.add(postReport1);
+
+        // 남아있는 게시물 신고
+        PostReport postReport2 = PostReport.builder()
+                .category(ReportCategory.ILLEGALITY)
+                .content("부적절한 내용이 포함된 게시글입니다.")
+                .status(ProcessingStatus.INPROGRESS)
+                .reporter(member1)
+                .reportedPost(post2)
+                .postContent(post2.getPostContent())
+                .isPostDeleted(false)
+                .build();
+        postReports.add(postReport2);
+
+        // 남아있는 게시물 신고
+        PostReport postReport3 = PostReport.builder()
+                .category(ReportCategory.ILLEGALITY)
+                .content("부적절한 내용이 포함된 게시글입니다.")
+                .status(ProcessingStatus.INPROGRESS)
+                .reporter(member2)
+                .reportedPost(post2)
+                .postContent(post2.getPostContent())
+                .isPostDeleted(false)
+                .build();
+        postReports.add(postReport3);
+
+        postReportRepository.saveAllAndFlush(postReports);
+
+
+        List<Keyword> keywords = new ArrayList<>();
+        Keyword keyword1 = new Keyword("Hello");
+        keywords.add(keyword1);
+        Keyword keyword2 = new Keyword("World");
+        keywords.add(keyword2);
+        Keyword keyword3 = new Keyword("Nice");
+        keywords.add(keyword3);
+
+        keywordRepository.saveAllAndFlush(keywords);
+
+
+        List<PostKeyword> postKeywords = new ArrayList<>();
+
+        PostKeyword postKeyword1 = PostKeyword.builder()
+                .postKeywordId(PostKeywordId.builder()
+                        .keywordNo(keyword1.getKeywordNo())
+                        .postNo(post1.getPostNo())
+                        .build())
+                .keyword(keyword1)
+                .post(post1)
+                .build();
+        postKeywords.add(postKeyword1);
+
+        PostKeyword postKeyword2 = PostKeyword.builder()
+                .postKeywordId(PostKeywordId.builder()
+                        .keywordNo(keyword2.getKeywordNo())
+                        .postNo(post2.getPostNo())
+                        .build())
+                .keyword(keyword2)
+                .post(post2)
+                .build();
+        postKeywords.add(postKeyword2);
+
+        postKeywordRepository.saveAllAndFlush(postKeywords);
+
+
+        List<Feedback> feedbacks = new ArrayList<>();
+
+        Feedback feedback1 = Feedback.builder()
+                .title("첫 번째 피드백")
+                .content("첫 번째 피드백 내용입니다.")
+                .hasReply(false)
+                .reply(null)
+                .category(FeedbackCategory.PROPOSAL)
+                .feedbackWriter(member1)
+                .build();
+        feedbacks.add(feedback1);
+
+        Feedback feedback2 = Feedback.builder()
+                .title("두 번째 피드백")
+                .content("두 번째 피드백 내용입니다.")
+                .hasReply(true)
+                .reply("두 번째 피드백에 대한 답변입니다.")
+                .category(FeedbackCategory.INQUIRY)
+                .feedbackWriter(member2)
+                .build();
+        feedbacks.add(feedback2);
+
+        feedbackRepository.saveAllAndFlush(feedbacks);
+
+        return ResponseEntity.ok(ApiResult.success("test용 dummy data 생성 성공", null));
+    }
+
+}

--- a/src/main/java/com/runninghi/runninghibackv2/common/dummy/TestData.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/dummy/TestData.java
@@ -35,7 +35,7 @@ public class TestData {
     private final KeywordRepository keywordRepository;
 
     @PostMapping("/test-data")
-    public ResponseEntity<ApiResult> setUp() {
+    public ResponseEntity<ApiResult<Void>> setUp() {
         List<Member> members = new ArrayList<>();
         LocalDateTime dateTime = LocalDateTime.now().minusDays(31);
 

--- a/src/main/java/com/runninghi/runninghibackv2/common/dummy/TestMemberRepository.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/dummy/TestMemberRepository.java
@@ -1,0 +1,12 @@
+package com.runninghi.runninghibackv2.common.dummy;
+
+import com.runninghi.runninghibackv2.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestMemberRepository extends JpaRepository<Member, Long> {
+
+    Member findByNickname(String nickname);
+
+}

--- a/src/main/java/com/runninghi/runninghibackv2/common/dummy/TestToken.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/dummy/TestToken.java
@@ -1,0 +1,89 @@
+package com.runninghi.runninghibackv2.common.dummy;
+
+import com.runninghi.runninghibackv2.auth.jwt.JwtTokenProvider;
+import com.runninghi.runninghibackv2.common.dto.AccessTokenInfo;
+import com.runninghi.runninghibackv2.common.dto.RefreshTokenInfo;
+import com.runninghi.runninghibackv2.common.response.ApiResult;
+import com.runninghi.runninghibackv2.domain.entity.Member;
+import com.runninghi.runninghibackv2.domain.enumtype.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TestToken {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TestMemberRepository testMemberRepository;
+
+    @PostMapping("/test-token")
+    public ResponseEntity<ApiResult<TestTokenResponse>> getTokens() {
+
+        List<Member> members = new ArrayList<>();
+
+        Member member1 = Member.builder()
+                .alarmConsent(true)
+                .kakaoName("관리자 : 카카오 이름")
+                .nickname("관리자 : 테스트용 관리자입니다.")
+                .level(0)
+                .isActive(true)
+                .totalDistance(0)
+                .distanceToNextLevel(10)
+                .role(Role.ADMIN)
+                .build();
+        members.add(member1);
+
+        Member member2 = Member.builder()
+                .alarmConsent(true)
+                .kakaoName("유저 : 카카오 이름")
+                .nickname("유저 : 테스트용 유저입니다.")
+                .level(1)
+                .isActive(true)
+                .totalDistance(0)
+                .distanceToNextLevel(10)
+                .role(Role.USER)
+                .build();
+        members.add(member2);
+
+        saveAllAndFlushMembers(members);
+
+        Member admin = testMemberRepository.findByNickname(member1.getNickname());
+        Member user = testMemberRepository.findByNickname(member2.getNickname());
+
+        AccessTokenInfo adminTokenInfo = AccessTokenInfo.from(admin);
+        AccessTokenInfo userTokenInfo = AccessTokenInfo.from(user);
+
+        String adminAccessToken = jwtTokenProvider.createAccessToken(adminTokenInfo);
+        String userAccessToken = jwtTokenProvider.createAccessToken(userTokenInfo);
+
+        RefreshTokenInfo adminRefreshTokenInfo = RefreshTokenInfo.from(admin);
+        RefreshTokenInfo userRefreshTokenInfo = RefreshTokenInfo.from(user);
+
+        String adminRefreshToken = jwtTokenProvider.createRefreshToken(adminRefreshTokenInfo);
+        String userRefreshToken = jwtTokenProvider.createRefreshToken(userRefreshTokenInfo);
+
+        member1.updateRefreshToken(adminRefreshToken);
+        member2.updateRefreshToken(userRefreshToken);
+
+        saveAllAndFlushMembers(members);
+
+        TokensAndInfo adminTokensAndInfo = TokensAndInfo.from(admin, adminAccessToken, adminRefreshToken);
+        TokensAndInfo userTokensAndInfo = TokensAndInfo.from(user, userAccessToken, userRefreshToken);
+
+        TestTokenResponse response = TestTokenResponse.from(adminTokensAndInfo, userTokensAndInfo);
+
+        return ResponseEntity.ok(ApiResult.success("test용 유저, 어드민 생성 성공. 토큰 발급 성공", response));
+    }
+
+    private void saveAllAndFlushMembers(List<Member> members) {
+        for (Member member : members) {
+            testMemberRepository.saveAndFlush(member);
+        }
+    }
+
+}

--- a/src/main/java/com/runninghi/runninghibackv2/common/dummy/TestTokenResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/dummy/TestTokenResponse.java
@@ -1,0 +1,10 @@
+package com.runninghi.runninghibackv2.common.dummy;
+
+public record TestTokenResponse(
+        TokensAndInfo admin,
+        TokensAndInfo user
+) {
+    public static TestTokenResponse from(TokensAndInfo admin, TokensAndInfo user) {
+        return new TestTokenResponse(admin, user);
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/common/dummy/TokensAndInfo.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/dummy/TokensAndInfo.java
@@ -1,0 +1,14 @@
+package com.runninghi.runninghibackv2.common.dummy;
+
+import com.runninghi.runninghibackv2.domain.entity.Member;
+
+public record TokensAndInfo(
+        Long memberNo,
+        String nickname,
+        String accessToken,
+        String refreshToken
+) {
+    public static TokensAndInfo from(Member member, String accessToken, String refreshToken) {
+        return new TokensAndInfo(member.getMemberNo(), member.getNickname(), accessToken, refreshToken);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈 #220 

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #220 

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- 테스트용 유저와 어드민을 생성하고 토큰 값을 반환하는 API
  - memberNo, nickname, accessToken, refreshToken 반환
- 더미 데이터를 생성하는 API
  - 따로 반환하는 데이터는 없고 성공 메세지만 반환합니다. 

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

더미 데이터와 테스트용 유저를 생성하는 API, 관련된 모든 파일들은 common/dummy에 넣어뒀습니다.
**추후 운영 서버에 올릴 떄는 dummy 폴더만 삭제하면 됩니다!** 

테스트를 위해 임의로 만든 유저다 보니 **카카오 서버와 통신하는 부분이 포함된 기능은 테스트 할 수 없습니다.** 
다른 기능들은 간단하게 확인했습니다. 만약 안되는 부분이 있다면 얘기해주세요!


더미 데이터 API는 스케줄링 테스트를 위해 사용했던거라서 안에 비어있는 컬럼이 많습니다 😂 
필요에 따라 추가하시고, 다른 사람들도 쓸 수 있게 업데이트 해주시면 좋을 것 같습니다!!


노션에 포스트맨 파일 업데이트 했습니다.
