### PR TITLE
[Feature - May 4th, 2024]{Score} 전체 랭킹, 회원 랭킹 조회 기능

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/controller/ScoreController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/controller/ScoreController.java
@@ -1,0 +1,57 @@
+package com.runninghi.runninghibackv2.application.controller;
+
+import com.runninghi.runninghibackv2.application.service.ScoreService;
+import com.runninghi.runninghibackv2.auth.jwt.JwtTokenProvider;
+import com.runninghi.runninghibackv2.common.response.ApiResult;
+import com.runninghi.runninghibackv2.application.dto.score.GetRankingResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/scores")
+@Tag(name = "주간 러닝 랭킹 API", description = "달린 거리에 따라 순위를 부여하는 주간 랭킹 API")
+public class ScoreController {
+
+    private final ScoreService scoreService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 전체 회원의 러닝 순위를 조회합니다. 달린 거리가 많을수록 높은 순위를 부여합니다.
+     * 동일한 값이 있을 경우 동일한 순위를 부여하고 다음 순위를 건너뜁니다.
+     * @return 순위값을 포함한 Score 리스트를 반환합니다.
+     */
+    @Operation(summary = "전체 러닝 랭킹 조회", description = "달린 거리를 기반으로 한 모든 회원의 러닝 순위를 조회합니다.")
+    @GetMapping("/ranking")
+    public ResponseEntity<ApiResult<List<GetRankingResponse>>> getAllRanking() {
+
+        List<GetRankingResponse> response = scoreService.getAllRanking();
+
+        return ResponseEntity.ok(ApiResult.success("전체 러닝 순위 조회 성공", response));
+    }
+
+    /**
+     * 특정 회원의 러닝 순위를 조회합니다. 전체 랭킹에서 로그인한 회원의 순위를 조회합니다.
+     * @return 순위값을 포함한 Score 데이터를 반환합니다.
+     * @apiNote 이 메서드를 사용하기 위해서는 요청 헤더에 유효한 Bearer 토큰이 포함되어야 합니다.
+     *          토큰이 유효하지 않거나, 토큰에 해당하는 사용자가 존재하지 않을 경우 접근이 거부됩니다.
+     */
+    @Operation(summary = "회원 러닝 랭킹 조회", description = "로그인한 회원의 러닝 순위를 조회합니다.")
+    @GetMapping("/ranking/member")
+    public ResponseEntity<ApiResult<GetRankingResponse>> getMemberRanking(
+            @RequestHeader(name = "Authorization") String bearerToken) {
+
+        Long memberNo = jwtTokenProvider.getMemberNoFromToken(bearerToken);
+        GetRankingResponse response = scoreService.getMemberRanking(memberNo);
+
+        return ResponseEntity.ok(ApiResult.success("회원 러닝 순위 조회 성공", response));
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/score/GetRankingResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/score/GetRankingResponse.java
@@ -1,0 +1,8 @@
+package com.runninghi.runninghibackv2.application.dto.score;
+
+public interface GetRankingResponse {
+    Long getScoreNo();
+    float getDistance();
+    String getNickname();
+    int getRank();
+}

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/PostService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/PostService.java
@@ -8,16 +8,17 @@ import com.runninghi.runninghibackv2.application.dto.post.request.UpdatePostRequ
 import com.runninghi.runninghibackv2.application.dto.post.response.*;
 import com.runninghi.runninghibackv2.domain.entity.Member;
 import com.runninghi.runninghibackv2.domain.entity.Post;
+import com.runninghi.runninghibackv2.domain.entity.Score;
 import com.runninghi.runninghibackv2.domain.entity.vo.GpxDataVO;
 import com.runninghi.runninghibackv2.domain.repository.MemberRepository;
 import com.runninghi.runninghibackv2.domain.repository.PostRepository;
+import com.runninghi.runninghibackv2.domain.repository.ScoreRepository;
 import com.runninghi.runninghibackv2.domain.service.GpxCalculator;
 import com.runninghi.runninghibackv2.domain.service.GpxCoordinateExtractor;
 import com.runninghi.runninghibackv2.domain.service.PostChecker;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -49,6 +50,7 @@ public class PostService {
     private final MemberRepository memberRepository;
     private final JPAQueryFactory jpaQueryFactory;
     private final GpxCoordinateExtractor gpxCoordinateExtractor;
+    private final ScoreRepository scoreRepository;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
@@ -125,6 +127,7 @@ public class PostService {
                 .status(false)
                 .build());
 
+        createOrUpdateScore(member, gpxDataVO);
         GpxDataVO postGpxVO = createdPost.getGpxDataVO();
 
         return new CreateRecordResponse(createdPost.getPostNo(), postGpxVO.getDistance(), postGpxVO.getTime(),
@@ -266,5 +269,18 @@ public class PostService {
         try (InputStream inputStream = url.openStream()) {
             return new GpxDataResponse(gpxCoordinateExtractor.extractCoordinates(inputStream));
         }
+    }
+
+    public void createOrUpdateScore(Member member, GpxDataVO gpxDataVO) {
+        Optional<Score> score = scoreRepository.findByMember(member);
+
+        if (scoreRepository.findByMember(member).isEmpty()) {
+            scoreRepository.save(Score.builder()
+                    .distance(gpxDataVO.getDistance())
+                    .member(member)
+                    .build());
+            return;
+        }
+        score.get().addDistance(gpxDataVO.getDistance());
     }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/ScoreService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/ScoreService.java
@@ -1,0 +1,23 @@
+package com.runninghi.runninghibackv2.application.service;
+
+import com.runninghi.runninghibackv2.application.dto.score.GetRankingResponse;
+import com.runninghi.runninghibackv2.domain.repository.ScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScoreService {
+
+    private final ScoreRepository scoreRepository;
+
+    public List<GetRankingResponse> getAllRanking() {
+        return scoreRepository.findAllRanking();
+    }
+
+    public GetRankingResponse getMemberRanking(Long memberNo) {
+        return scoreRepository.findMemberRanking(memberNo);
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/common/schedule/ScoreCleanUpBatch.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/schedule/ScoreCleanUpBatch.java
@@ -1,0 +1,18 @@
+package com.runninghi.runninghibackv2.common.schedule;
+
+import com.runninghi.runninghibackv2.domain.repository.ScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScoreCleanUpBatch {
+
+    private final ScoreRepository scoreRepository;
+
+    @Scheduled(cron = "0 0 0 ? * 2")
+    public void cleanUpWeeklyScore() {
+        scoreRepository.deleteAll();
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/domain/entity/Score.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/entity/Score.java
@@ -1,0 +1,42 @@
+package com.runninghi.runninghibackv2.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Entity
+@Getter
+@Table(name = "TBL_SCORE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Score {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long scoreNo;
+
+    @Column
+    @Comment("달린 거리")
+    private float distance;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_no")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @Comment("점수 소유자")
+    private Member member;
+
+    @Builder
+    public Score(Long scoreNo, float distance, Member member) {
+        this.scoreNo = scoreNo;
+        this.distance = distance;
+        this.member = member;
+    }
+
+    public void addDistance(float distance) {
+        this.distance += distance;
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/domain/repository/ScoreRepository.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/repository/ScoreRepository.java
@@ -1,0 +1,26 @@
+package com.runninghi.runninghibackv2.domain.repository;
+
+import com.runninghi.runninghibackv2.application.dto.score.GetRankingResponse;
+import com.runninghi.runninghibackv2.domain.entity.Member;
+import com.runninghi.runninghibackv2.domain.entity.Score;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ScoreRepository extends JpaRepository<Score, Long> {
+    Optional<Score> findByMember(Member member);
+
+    @Query("SELECT s.scoreNo, s.distance, s.member.nickname," +
+            "RANK() OVER (ORDER BY s.distance DESC) AS rank FROM Score s")
+    List<GetRankingResponse> findAllRanking();
+
+    @Query("SELECT s.scoreNo, s.distance, s.member.nickname, " +
+            "(SELECT COUNT(*) + 1 FROM Score s2 WHERE s2.distance > s.distance)" +
+            "FROM Score s WHERE s.member.memberNo = :memberNo")
+    GetRankingResponse findMemberRanking(@Param("memberNo") Long memberNo);
+}

--- a/src/main/java/com/runninghi/runninghibackv2/domain/repository/ScoreRepository.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/repository/ScoreRepository.java
@@ -15,12 +15,12 @@ import java.util.Optional;
 public interface ScoreRepository extends JpaRepository<Score, Long> {
     Optional<Score> findByMember(Member member);
 
-    @Query("SELECT s.scoreNo, s.distance, s.member.nickname," +
+    @Query("SELECT s.scoreNo AS scoreNo, s.distance AS distance, s.member.nickname AS nickname," +
             "RANK() OVER (ORDER BY s.distance DESC) AS rank FROM Score s")
     List<GetRankingResponse> findAllRanking();
 
-    @Query("SELECT s.scoreNo, s.distance, s.member.nickname, " +
-            "(SELECT COUNT(*) + 1 FROM Score s2 WHERE s2.distance > s.distance)" +
+    @Query("SELECT s.scoreNo AS scoreNo, s.distance AS distance, s.member.nickname AS nickname, " +
+            "(SELECT COUNT(*) + 1 FROM Score s2 WHERE s2.distance > s.distance) AS rank " +
             "FROM Score s WHERE s.member.memberNo = :memberNo")
     GetRankingResponse findMemberRanking(@Param("memberNo") Long memberNo);
 }


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
* closed #165 

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- Score 엔티티 생성
- Post 생성 시 Score 데이터 생성. 이후 Post 생성될 때마다 달린 거리 업데이트
- 전체 랭킹 조회 기능
- 회원 랭킹 조회 기능
- 스케쥴러 사용하여 매주 월요일 00시에 Score 초기화

달린 거리가 많을 수록 높은 순위를 부여합니다.
동점자가 있는 경우 동일한 순위를 부여하고 다음 순위를 건너뛰도록 했습니다.
Post쪽 Record 생성 부분에 Score 업데이트하는 부분 추가했습니다.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
쿼리에 rank()라는 함수가 있더라구용 동점인 경우 동일한 순위를 부여하기 위해 orderBy 대신 rank를 사용했습니다.
쿼리 dsl로 구현하고 싶었는데 rank함수를 사용할 수 없어서 jpql로 구현했습니다.
<br>
<br>

