### PR TITLE
[Feature - May 3rd, 2024] - {Member} 토큰 유효성 체크 API

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
@@ -210,8 +210,19 @@ public class MemberController {
     }
 
 
-    // 자동 로그인 : 액세스 토큰
-    @PostMapping("/api/v1/login/validate-token")
+    /**
+     * 액세스 토큰의 유효성을 검사하여 자동 로그인을 처리하는 API입니다.
+     *
+     * <p>이 메서드는 사용자의 액세스 토큰을 검사하여 유효한 경우 자동 로그인을 처리합니다.
+     * 만료되었거나 유효하지 않은 경우 적절한 응답을 반환합니다.</p>
+     *
+     * @param token 사용자 인증을 위한 Bearer 토큰. 요청 헤더에 포함되어야 합니다.
+     * @return ResponseEntity 객체를 통해 ApiResult 타입의 응답을 반환합니다.
+     * @apiNote 이 메서드를 사용하기 위해서는 요청 헤더에 유효한 Bearer 토큰이 포함되어야 합니다.
+     *          토큰이 유효하지 않거나, 토큰에 해당하는 사용자가 인증되지 않았을 경우 접근이 거부됩니다.
+     */
+    @PostMapping("/api/v1/login/access-token/validate")
+    @Operation(summary = "자동 로그인의 액세스 토큰 유효성 검사", description = "액세스 토큰의 유효성을 검사하여 자동 로그인을 처리합니다.")
     public ResponseEntity<ApiResult<Void>> autoLoginWithAccessToekn(@RequestHeader(value = "Authorization") String token) {
         try {
             if (jwtTokenProvider.validateAutoLoginAccessToken(token)) {
@@ -228,8 +239,18 @@ public class MemberController {
     }
 
 
-    // 자동 로그인 : 리프레시 토큰
-    @PostMapping("/api/v1/login/validate-refresh-token")
+    /**
+     * 리프레시 토큰의 유효성을 검사하여 자동 로그인을 처리하고 새로운 액세스 토큰을 발급하는 API입니다.
+     *
+     * <p>이 메서드는 사용자의 리프레시 토큰을 검사하여 유효한 경우 새로운 액세스 토큰을 발급합니다. 만료되었거나 유효하지 않은 경우 적절한 응답을 반환합니다.</p>
+     *
+     * @param refreshToken 사용자 인증을 위한 리프레시 토큰. 요청 헤더에 포함되어야 합니다.
+     * @return ResponseEntity 객체를 통해 ApiResult 타입의 응답을 반환합니다. 새로운 액세스 토큰이 응답 헤더에 포함됩니다.
+     * @apiNote 이 메서드를 사용하기 위해서는 요청 헤더에 유효한 리프레시 토큰이 포함되어야 합니다.
+     *          토큰이 유효하지 않거나, 토큰에 해당하는 사용자가 인증되지 않았을 경우 접근이 거부됩니다.
+     */
+    @PostMapping("/api/v1/login/refresh-token/validate")
+    @Operation(summary = "자동 로그인의 리프레시 토큰 유효성 검사 및 액세스 토큰 갱신", description = "리프레시 토큰의 유효성을 검사하여 자동 로그인을 처리하고 새로운 액세스 토큰을 발급합니다.")
     public ResponseEntity<ApiResult<Void>> autoLoginWithRefreshToken(@RequestHeader("RefreshToekn") String refreshToken) {
         try {
             if (jwtTokenProvider.validateAutoLoginRefreshToken(refreshToken)) {

--- a/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
@@ -56,11 +56,7 @@ public class MemberController {
                             headers = {
                                     @Header(name = "Authorization", description = "Access Token", schema = @Schema(type = "string")),
                                     @Header(name = "Refresh-Token", description = "Refresh Token", schema = @Schema(type = "string"))
-                            },
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResult.class)
-                            )
+                            }
                     )
             }
     )
@@ -140,7 +136,7 @@ public class MemberController {
             parameters = {
                     @Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "사용자 인증을 위한 Bearer 토큰", required = true)
             },
-            responses = { @ApiResponse(responseCode = "200", description = "회원 정보 업데이트 성공", content = @Content(schema = @Schema(implementation = ApiResult.class))) }
+            responses = { @ApiResponse(responseCode = "200", description = "회원 정보 업데이트 성공") }
     )
     public ResponseEntity<ApiResult<UpdateMemberInfoResponse>> updateMemberInfo(
             @RequestHeader(value = "Authorization") String token,
@@ -171,7 +167,7 @@ public class MemberController {
             parameters = {
                     @Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "사용자 인증을 위한 Bearer 토큰", required = true)
             },
-            responses = { @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공", content = @Content(schema = @Schema(implementation = ApiResult.class))) }
+            responses = { @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공") }
     )
     public ResponseEntity<ApiResult<GetMemberResponse>> getMemberInfo(@RequestHeader(value = "Authorization") String token) {
 
@@ -211,30 +207,43 @@ public class MemberController {
 
 
     /**
-     * 액세스 토큰의 유효성을 검사하여 자동 로그인을 처리하는 API입니다.
+     * 자동 로그인의 액세스 토큰 유효성 검사 API입니다.
      *
-     * <p>이 메서드는 사용자의 액세스 토큰을 검사하여 유효한 경우 자동 로그인을 처리합니다.
-     * 만료되었거나 유효하지 않은 경우 적절한 응답을 반환합니다.</p>
+     * <p>이 메서드는 액세스 토큰의 유효성을 검사하여 자동 로그인을 처리합니다. 유효한 토큰인 경우 성공 응답을 반환하고, 만료된 토큰인 경우 적절한 에러 메시지를 반환합니다.</p>
      *
-     * @param token 사용자 인증을 위한 Bearer 토큰. 요청 헤더에 포함되어야 합니다.
-     * @return ResponseEntity 객체를 통해 ApiResult 타입의 응답을 반환합니다.
-     * @apiNote 이 메서드를 사용하기 위해서는 요청 헤더에 유효한 Bearer 토큰이 포함되어야 합니다.
-     *          토큰이 유효하지 않거나, 토큰에 해당하는 사용자가 인증되지 않았을 경우 접근이 거부됩니다.
+     * @param token 검사할 액세스 토큰. 요청 헤더에 "Authorization" 키로 포함되어야 합니다.
+     * @return ResponseEntity 객체를 통해 ApiResult 타입의 응답을 반환합니다. 응답 본문에는 토큰 유효성 검사 결과가 포함됩니다.
+     *          유효한 토큰은 true, 만료된 토큰은 false, 서명이 일치하지않는 토큰은 null 값이 응답 본문에 포함됩니다.
+     * @apiNote 이 메서드를 사용하기 위해서는 요청 헤더에 유효한 액세스 토큰이 포함되어야 합니다.
+     *          토큰이 유효하지 않거나, 만료된 경우 적절한 에러 응답을 반환합니다.
      */
-    @PostMapping("/api/v1/login/access-token/validate")
-    @Operation(summary = "자동 로그인의 액세스 토큰 유효성 검사", description = "액세스 토큰의 유효성을 검사하여 자동 로그인을 처리합니다.")
-    public ResponseEntity<ApiResult<Void>> autoLoginWithAccessToekn(@RequestHeader(value = "Authorization") String token) {
+    @PostMapping(value = "/api/v1/login/access-token/validate", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "자동 로그인의 엑세스 토큰 유효성 검사",
+            description = "리프레시 토큰의 유효성을 검사하여 자동 로그인을 처리하고 새로운 액세스 토큰을 발급합니다. 응답 본문에는 토큰 유효성 검사 결과가 포함됩니다.\n" +
+                            "유효한 토큰은 true, 만료된 토큰은 false, 서명이 일치하지않는 토큰은 null 값이 응답 본문에 포함됩니다.",
+            parameters = {
+                    @Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "사용자 인증을 위한 Bearer 토큰", required = true)
+            },
+            responses = { @ApiResponse(responseCode = "200", description = "자동 로그인 : 엑세스 토큰 유효성 검사 성공"),
+                    @ApiResponse(responseCode = "403", description = "자동 로그인 : 만료된 엑세스 토큰입니다.",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(example = "{\"timeStamp\": \"2024-05-23T07:36:26.119Z\", \"status\": \"FORBIDDEN\", \"message\": \"자동 로그인 : 만료된 엑세스 토큰입니다.\", \"data\": false}"))),
+                    @ApiResponse(responseCode = "401", description = "자동 로그인 : 유효하지않은 엑세스 토큰입니다.",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(example = "{\"timeStamp\": \"2024-05-23T07:36:26.119Z\", \"status\": \"UNAUTHORIZED\", \"message\": \"자동 로그인 : 유효하지않은 엑세스 토큰입니다.\", \"data\": null}"))),
+            })
+    public ResponseEntity<ApiResult<Boolean>> autoLoginWithAccessToekn(@RequestHeader(value = "Authorization") String token) {
         try {
             if (jwtTokenProvider.validateAutoLoginAccessToken(token)) {
                 // Access Token이 유효한 경우
-                return ResponseEntity.ok(ApiResult.success("자동 로그인 : 토큰 유효성 검사 성공", null));
+                return ResponseEntity.ok(ApiResult.success("자동 로그인 : 엑세스 토큰 유효성 검사 성공", true));
             } else {
                 // Access Token이 만료된 경우
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResult.error(HttpStatus.UNAUTHORIZED, "자동 로그인 : 만료된 토큰입니다."));
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResult.error(HttpStatus.FORBIDDEN, "자동 로그인 : 만료된 엑세스 토큰입니다.", false));
             }
         } catch (InvalidTokenException e) {
             // Access Token이 유효하지 않은 경우
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResult.error(HttpStatus.UNAUTHORIZED, "자동 로그인 : 유효하지않은 토큰입니다."));
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResult.error(HttpStatus.UNAUTHORIZED, "자동 로그인 : 유효하지않은 엑세스 토큰입니다."));
         }
     }
 
@@ -244,14 +253,29 @@ public class MemberController {
      *
      * <p>이 메서드는 사용자의 리프레시 토큰을 검사하여 유효한 경우 새로운 액세스 토큰을 발급합니다. 만료되었거나 유효하지 않은 경우 적절한 응답을 반환합니다.</p>
      *
-     * @param refreshToken 사용자 인증을 위한 리프레시 토큰. 요청 헤더에 포함되어야 합니다.
-     * @return ResponseEntity 객체를 통해 ApiResult 타입의 응답을 반환합니다. 새로운 액세스 토큰이 응답 헤더에 포함됩니다.
+     * @param refreshToken 사용자 인증을 위한 리프레시 토큰. 요청 헤더에 "Refresh-Token" 키로 포함되어야 합니다.
+     * @return ResponseEntity 객체를 통해 ApiResult 타입의 응답을 반환합니다. 토큰이 유효한 경우 true값이 응답 본문에 들어가며, 새로운 액세스 토큰이 응답 헤더에 포함됩니다.
+     *          토큰이 만료된 경우 false, 서명이 유효하지않은 경우 null 값이 응답 본문에 포함됩니다.
      * @apiNote 이 메서드를 사용하기 위해서는 요청 헤더에 유효한 리프레시 토큰이 포함되어야 합니다.
      *          토큰이 유효하지 않거나, 토큰에 해당하는 사용자가 인증되지 않았을 경우 접근이 거부됩니다.
      */
-    @PostMapping("/api/v1/login/refresh-token/validate")
-    @Operation(summary = "자동 로그인의 리프레시 토큰 유효성 검사 및 액세스 토큰 갱신", description = "리프레시 토큰의 유효성을 검사하여 자동 로그인을 처리하고 새로운 액세스 토큰을 발급합니다.")
-    public ResponseEntity<ApiResult<Void>> autoLoginWithRefreshToken(@RequestHeader("RefreshToekn") String refreshToken) {
+    @PostMapping(value = "/api/v1/login/refresh-token/validate", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "자동 로그인의 리프레시 토큰 유효성 검사 및 액세스 토큰 갱신",
+            description = "리프레시 토큰의 유효성을 검사하여 자동 로그인을 처리하고 새로운 액세스 토큰을 발급합니다. " +
+                    "토큰이 유효한 경우 true 값이 응답 본문에 들어가며, 새로운 액세스 토큰이 응답 헤더에 포함됩니다.\n" +
+                    "토큰이 만료된 경우 false, 서명이 유효하지않은 경우 null 값이 응답 본문에 포함됩니다.",
+            parameters = {
+                    @Parameter(in = ParameterIn.HEADER, name = "Refresh-Token", description = "사용자 인증을 위한 Refresh 토큰", required = true)
+            },
+            responses = { @ApiResponse(responseCode = "200", description = "자동 로그인 : 리프레시 토큰 유효성 검사 성공. 새로운 액세스 토큰 발급"),
+                          @ApiResponse(responseCode = "403", description = "자동 로그인 : 만료된 리프레시 토큰입니다. 다시 로그인해주세요.",
+                            content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"timeStamp\": \"2024-05-23T07:36:26.119Z\", \"status\": \"FORBIDDEN\", \"message\": \"자동 로그인 : 만료된 리프레시 토큰입니다. 다시 로그인해주세요.\", \"data\": false}"))),
+                          @ApiResponse(responseCode = "401", description = "자동 로그인 : 유효하지않은 리프레시 토큰입니다.",
+                            content = @Content(mediaType = "application/json",
+                            schema = @Schema(example = "{\"timeStamp\": \"2024-05-23T07:36:26.119Z\", \"status\": \"UNAUTHORIZED\", \"message\": \"자동 로그인 : 유효하지않은 리프레시 토큰입니다.\", \"data\": null}"))),
+            })
+    public ResponseEntity<ApiResult<Boolean>> autoLoginWithRefreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
         try {
             if (jwtTokenProvider.validateAutoLoginRefreshToken(refreshToken)) {
                 // Refresh Token이 유효한 경우 새로운 Access Token 발급
@@ -262,14 +286,14 @@ public class MemberController {
 
                 return ResponseEntity.ok()
                         .headers(headers)
-                        .body((ApiResult.success("새로운 액세스 토큰 발급", null)));
+                        .body((ApiResult.success("새로운 액세스 토큰 발급", true)));
             } else {
                 // Refresh Token이 만료된 경우
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResult.error(HttpStatus.UNAUTHORIZED, "자동 로그인 : 만료된 토큰입니다. 다시 로그인해주세요."));
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResult.error(HttpStatus.FORBIDDEN, "자동 로그인 : 만료된 토큰입니다. 다시 로그인해주세요.", false));
             }
         } catch (InvalidTokenException e) {
             // Refresh Token이 유효하지 않은 경우
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResult.error(HttpStatus.UNAUTHORIZED, "자동 로그인 : 유효하지않은 토큰입니다."));
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResult.error(HttpStatus.UNAUTHORIZED, "자동 로그인 : 유효하지않은 토큰입니다.", null));
         }
     }
 

--- a/src/main/java/com/runninghi/runninghibackv2/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/runninghi/runninghibackv2/auth/jwt/JwtTokenProvider.java
@@ -175,7 +175,7 @@ public class JwtTokenProvider {
      * 자동 로그인 토큰의 유효성을 검사합니다.
      *
      * @param token 검사할 자동 로그인 토큰
-     * @return 토큰이 유효한 경우 true를 반환하고, 그렇지 않은 경우 false를 반환합니다.
+     * @return 토큰이 유효한 경우 true를 반환하고, 만료된 경우 false를 반환합니다.
      * @throws InvalidTokenException 토큰이 유효하지 않은 경우 발생하는 예외입니다.
      */
     public boolean validateAutoLoginAccessToken(String token) throws InvalidTokenException {
@@ -193,7 +193,7 @@ public class JwtTokenProvider {
      * 자동 로그인 토큰의 유효성을 검사합니다.
      *
      * @param token 검사할 자동 로그인 토큰
-     * @return 토큰이 유효한 경우 true를 반환하고, 그렇지 않은 경우 false를 반환합니다.
+     * @return 토큰이 유효한 경우 true를 반환하고, 만료된 경우 false를 반환합니다.
      * @throws InvalidTokenException 토큰이 유효하지 않은 경우 발생하는 예외입니다.
      */
     public boolean validateAutoLoginRefreshToken(String token) throws InvalidTokenException {

--- a/src/main/java/com/runninghi/runninghibackv2/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/runninghi/runninghibackv2/auth/jwt/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import com.runninghi.runninghibackv2.common.dto.RefreshTokenInfo;
 import com.runninghi.runninghibackv2.domain.enumtype.Role;
 import com.runninghi.runninghibackv2.common.exception.custom.InvalidTokenException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.servlet.http.HttpServletRequest;
@@ -67,7 +68,7 @@ public class JwtTokenProvider {
     /**
      * 리프레시 토큰을 재생성합니다.
      *
-     * @param memberJwtInfo 멤버 정보를 담고 있는 객체
+     * @param refreshTokenInfo 멤버 정보를 담고 있는 객체
      * @return 생성된 리프레시 토큰
      */
     public String createRefreshToken(RefreshTokenInfo refreshTokenInfo) {
@@ -165,6 +166,42 @@ public class JwtTokenProvider {
     public void validateRefreshToken(String token) throws InvalidTokenException {
         try {
             Jwts.parserBuilder().setSigningKey(secretKey.getBytes()).build().parseClaimsJws(token);
+        } catch (Exception e) {
+            throw new InvalidTokenException();
+        }
+    }
+
+    /**
+     * 자동 로그인 토큰의 유효성을 검사합니다.
+     *
+     * @param token 검사할 자동 로그인 토큰
+     * @return 토큰이 유효한 경우 true를 반환하고, 그렇지 않은 경우 false를 반환합니다.
+     * @throws InvalidTokenException 토큰이 유효하지 않은 경우 발생하는 예외입니다.
+     */
+    public boolean validateAutoLoginAccessToken(String token) throws InvalidTokenException {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey.getBytes()).build().parseClaimsJws(token.substring(7));
+            return true;
+        } catch (ExpiredJwtException e) {
+            return false;
+        } catch (Exception e) {
+            throw new InvalidTokenException();
+        }
+    }
+
+    /**
+     * 자동 로그인 토큰의 유효성을 검사합니다.
+     *
+     * @param token 검사할 자동 로그인 토큰
+     * @return 토큰이 유효한 경우 true를 반환하고, 그렇지 않은 경우 false를 반환합니다.
+     * @throws InvalidTokenException 토큰이 유효하지 않은 경우 발생하는 예외입니다.
+     */
+    public boolean validateAutoLoginRefreshToken(String token) throws InvalidTokenException {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey.getBytes()).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            return false;
         } catch (Exception e) {
             throw new InvalidTokenException();
         }

--- a/src/main/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilter.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/filter/JwtTokenFilter.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -71,10 +72,14 @@ public class JwtTokenFilter extends OncePerRequestFilter {
      */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String[] excludePath = {"/login/kakao"};
+        String[] excludePaths = {
+                "/login/**",        // /login 경로와 하위 경로 모두 제외
+                "/api/v1/login/**"  // /api/v1/login 경로와 하위 경로 모두 제외
+        };
         String path = request.getRequestURI();
+        AntPathMatcher pathMatcher = new AntPathMatcher();
 
-        return Arrays.stream(excludePath).anyMatch(path::contains);
+        return Arrays.stream(excludePaths).anyMatch(excludePath -> pathMatcher.match(excludePath, path));
     }
 
     /**

--- a/src/main/java/com/runninghi/runninghibackv2/common/response/ApiResult.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/response/ApiResult.java
@@ -16,8 +16,8 @@ public record ApiResult<T>(
         T data
 ) {
 
-    public static <T> ApiResult<T> success(String message, T data) {
-        return new ApiResult<>(LocalDateTime.now(), HttpStatus.OK, message, data);
+    public static <T> ApiResult<T> success(String errorMessage, T data) {
+        return new ApiResult<>(LocalDateTime.now(), HttpStatus.OK, errorMessage, data);
     }
 
     public static <T> ApiResult<T> error(ErrorCode errorCode) {
@@ -27,6 +27,10 @@ public record ApiResult<T>(
 
     public static <T> ApiResult<T> error(HttpStatus httpStatus, String errorMessage) {
         return new ApiResult<>(LocalDateTime.now(), httpStatus, errorMessage, null);
+    }
+
+    public static <T> ApiResult<T> error(HttpStatus httpStatus, String errorMessage, T data) {
+        return new ApiResult<>(LocalDateTime.now(), httpStatus, errorMessage, data);
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈 #243

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

- closed #243

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- 자동 로그인을 위해 토큰의 유효성을 체크하고 반환하는 API 생성
  - 엑세스 토큰을 확인하는 API 
  - 리프레시 토큰을 확인하는 API 
    - 리프레시 토큰이 유효할 경우, 헤더에 새롭게 생성한 엑세스 토큰을 포함하여 반환함 
- API  반환값과 HTTP 상태 코드
  - 토큰이 유효할 경우 = data 값은 `true`, status는 `200 ok`
  - 토큰이 만료됐을 경우 = data 값은 `false`, status는 `403 forbbiden` 
  - 토큰의 서명이 유효하지않을 경우 = data 값은 `null`, status는 `401 Unauthorized`

**자동 로그인 플로우**
먼저 `엑세스 토큰 API`로 엑세스 토큰의 유효성을 검사합니다. 
유효하다면 그대로 로그인이 진행되지만, 만료됐을 경우 `리프레시 토큰 API`로 리프레시 토큰의 유효성을 검사해야합니다. 
만약 리프레시 토큰이 유효할 경우, 서버에서 새로 엑세스 토큰을 발급하여 헤더에 포함시켜 응답을 반환합니다. 
만약 리프레시 토큰도 만료되거나 유효하지않을시(서명이 일치하지않는 경우) 사용자가 직접 로그인해야합니다. 


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

valid, expired, invalid를 data로 표현하기 위해 ApiResult의 error 오버로딩 메서드를 추가했습니다. 
API를 추가하면서 필터 제외 경로를 추가했습니다. 경로가 추가되면서, 와일드카드(*, **)를 써서 경로를 세밀하게 처리하기 위해 AntPathMatcher를 사용하도록 수정했습니다. 