### PR TITLE
[Feature- Jun 1st, 2024] - {ALL} 현재, 전체 페이지만 나오도록 응답 결과 커스텀

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/controller/PostController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/controller/PostController.java
@@ -7,6 +7,8 @@ import com.runninghi.runninghibackv2.common.annotations.HasAccess;
 import com.runninghi.runninghibackv2.common.dto.AccessTokenInfo;
 import com.runninghi.runninghibackv2.common.response.ApiResult;
 import com.runninghi.runninghibackv2.application.service.PostService;
+import com.runninghi.runninghibackv2.common.response.PageResult;
+import com.runninghi.runninghibackv2.common.response.PageResultData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Pattern;
@@ -40,13 +42,13 @@ public class PostController {
     private static final String DELETE_RESPONSE_MESSAGE = "성공적으로 삭제되었습니다.";
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(summary = "게시글 리스트 조회", description = "게시글 전체 리스트를 조회합니다.\n 특정 키워드들로 필터링이 가능합니다.")
-    public ResponseEntity<ApiResult<Page<GetAllPostsResponse>>> getAllPosts(@RequestParam(defaultValue = "0") int page) {
+    @Operation(summary = "게시글 리스트 조회", description = "게시글 전체 리스트를 조회합니다.\n 난이도/지열별로 필터링이 가능합니다.")
+    public ResponseEntity<PageResult<GetAllPostsResponse>> getAllPosts(@RequestParam(defaultValue = "0") int page) {
         Pageable pageable = PageRequest.of(page, 10);
 
-        Page<GetAllPostsResponse> response = postService.getPostScroll(pageable);
+        PageResultData<GetAllPostsResponse> response = postService.getPostScroll(pageable);
 
-        return ResponseEntity.ok(ApiResult.success(GET_MAPPING_RESPONSE_MESSAGE, response));
+        return ResponseEntity.ok(PageResult.success(GET_MAPPING_RESPONSE_MESSAGE, response));
     }
 
     @GetMapping(value = "my-feed",produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/PostService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/PostService.java
@@ -7,6 +7,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.runninghi.runninghibackv2.application.dto.post.request.CreatePostRequest;
 import com.runninghi.runninghibackv2.application.dto.post.request.UpdatePostRequest;
 import com.runninghi.runninghibackv2.application.dto.post.response.*;
+import com.runninghi.runninghibackv2.common.response.PageResult;
+import com.runninghi.runninghibackv2.common.response.PageResultData;
 import com.runninghi.runninghibackv2.domain.entity.*;
 import com.runninghi.runninghibackv2.domain.entity.vo.GpsDataVO;
 import com.runninghi.runninghibackv2.domain.repository.MemberRepository;
@@ -96,7 +98,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public Page<GetAllPostsResponse> getPostScroll(Pageable pageable) {
+    public PageResultData<GetAllPostsResponse> getPostScroll(Pageable pageable) {
         return postQueryRepository.findAllPostsByPageable(pageable);
     }
 

--- a/src/main/java/com/runninghi/runninghibackv2/common/response/PageResult.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/response/PageResult.java
@@ -1,0 +1,39 @@
+package com.runninghi.runninghibackv2.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+
+/**
+ * PageResult 클래스는 페이징된 API 응답을 위한 레코드 클래스입니다.
+ *
+ * @param <T> 페이지 내용의 타입을 나타냅니다.
+ */
+public record PageResult<T>(
+        @Schema(description = "응답 시간", example = "2024-03-27T14:20:52.026425")
+        LocalDateTime timeStamp,
+        @Schema(description = "응답 상태", example = "OK")
+        String status,
+        @Schema(description = "응답 메시지", example = "성공적으로 조회되었습니다.")
+        String message,
+        @Schema(description = "페이징 응답 데이터")
+        PageResultData<T> data
+) {
+    public PageResult(String status, String message, PageResultData<T> data) {
+        this(LocalDateTime.now(), status, message, data);
+    }
+
+    public static <T> PageResult<T> success(String message, PageResultData<T> data) {
+        return new PageResult<>("OK", message, data);
+    }
+
+    public static <T> PageResult<T> error(HttpStatus status, String message) {
+        return new PageResult<>(status.name(), message, null);
+    }
+
+    public static <T> PageResult<T> error(HttpStatus status, String message, PageResultData<T> data) {
+        return new PageResult<>(status.name(), message, data);
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/common/response/PageResultData.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/response/PageResultData.java
@@ -1,0 +1,28 @@
+package com.runninghi.runninghibackv2.common.response;
+
+import java.util.List;
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+public class PageResultData<T> {
+    private List<T> content;
+    private int pageNumber;
+    private int totalPages;
+
+    /**
+     * PageResultData 생성자. 페이지화된 결과 데이터를 초기화합니다.
+     *
+     * @param content 페이지의 내용 리스트
+     * @param pageable 페이지 정보 (페이지 번호와 크기 등을 포함)
+     * @param total 전체 항목 수
+     *
+     * 추후 필요한 데이터를 더 추가할 수 있습니다.
+     */
+    public PageResultData(List<T> content, Pageable pageable, long total) {
+        this.content = content;
+        this.pageNumber = pageable.getPageNumber();
+        this.totalPages = (int) Math.floor((double) total / pageable.getPageSize());
+    }
+}
+

--- a/src/main/java/com/runninghi/runninghibackv2/domain/repository/PostQueryRepository.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/repository/PostQueryRepository.java
@@ -1,10 +1,11 @@
 package com.runninghi.runninghibackv2.domain.repository;
 
 import com.runninghi.runninghibackv2.application.dto.post.response.GetAllPostsResponse;
+import com.runninghi.runninghibackv2.common.response.PageResultData;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PostQueryRepository {
-    Page<GetAllPostsResponse> findAllPostsByPageable(Pageable pageable);
+    PageResultData<GetAllPostsResponse> findAllPostsByPageable(Pageable pageable);
     Page<GetAllPostsResponse> findMyPostsByPageable(Pageable pageable, Long memberNo);
 }

--- a/src/main/java/com/runninghi/runninghibackv2/infrastructure/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/runninghi/runninghibackv2/infrastructure/repository/PostQueryRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.runninghi.runninghibackv2.infrastructure.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.runninghi.runninghibackv2.application.dto.post.response.GetAllPostsResponse;
+import com.runninghi.runninghibackv2.common.response.PageResult;
+import com.runninghi.runninghibackv2.common.response.PageResultData;
 import com.runninghi.runninghibackv2.domain.entity.Image;
 import com.runninghi.runninghibackv2.domain.entity.Post;
 import com.runninghi.runninghibackv2.domain.entity.QImage;
@@ -26,7 +28,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
     @Override
     @Transactional(readOnly = true)
-    public Page<GetAllPostsResponse> findAllPostsByPageable(Pageable pageable) {
+    public PageResultData<GetAllPostsResponse> findAllPostsByPageable(Pageable pageable) {
         List<Post> posts;
         long total;
 
@@ -48,7 +50,7 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
             return GetAllPostsResponse.from(post, imageUrl);
         }).collect(Collectors.toList());
 
-        return new PageImpl<>(responses, pageable, total);
+        return new PageResultData<>(responses, pageable, total);
     }
 
     @Override


### PR DESCRIPTION
## 📌 관련 이슈

* closed #281 

## ✨ 과제 내용

- 리스트 조회 (전체 조회) 시 페이징 결과가 현재, 전체만 나오도록 응답 커스텀

- 


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

### 결과

```json
{
    "timeStamp": "2024-06-06T14:22:59.4746642",
    "status": "OK",
    "message": "성공적으로 조회되었습니다.",
    "data": {
        "content": [
            {
                "postNo": 51,
                "createDate": "2023-10-18T18:43:36",
                "postContent": "47 번째 게시글입니다.",
                "role": "ADMIN",
                "nickname": "관리자 : 테스트용 관리자입니다.",
                "profileImageUrl": null,
                "kcal": 596.0,
                "imageUrl": null
            },
            {
                "postNo": 52,
                "createDate": "2024-01-17T20:12:01",
                "postContent": "48 번째 게시글입니다.",
                "role": "ADMIN",
                "nickname": "관리자 : 테스트용 관리자입니다.",
                "profileImageUrl": null,
                "kcal": 249.0,
                "imageUrl": null
            }
        ],
        "pageNumber": 5,
        "totalPages": 6
    }
}
```
- 기존 ApiResult 와 동일한 형식으로 만들었습니다
- PageResultData 에서 pageable 중 필요한 데이터만 가져오는 방식입니다.
- 기존 
return new PageImpl<> 을  **return new PageResultData<>** 로 변경해주시면 됩니다!!

- 혹시 다른 방법이 더 나을 것 같으면 알려주세요!!