### PR TITLE
[Refactoring - Jun 3rd, 2024]{Challenge} Challenge 엔티티 변경, MemberChallenge 기록 업데이트 방식 변경

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/challenge/request/CreateChallengeRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/challenge/request/CreateChallengeRequest.java
@@ -12,8 +12,10 @@ public record CreateChallengeRequest(
         String content,
         @Schema(description = "챌린지 타입", example = "DISTANCE")
         ChallengeCategory challengeCategory,
+        @Schema(description = "챌린지 이미지", example = "test.jpg")
+        String imageUrl,
         @Schema(description = "목표 수치", example = "100.0")
-        float targetValue,
+        String targetValue,
         @Schema(description = "챌린지 시작일자", example = "2024-06-01T00:00:00")
         LocalDateTime startDate,
         @Schema(description = "챌린지 종료일자", example = "2024-0.6-30T00:00:00")

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/challenge/request/UpdateChallengeRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/challenge/request/UpdateChallengeRequest.java
@@ -12,8 +12,10 @@ public record UpdateChallengeRequest(
         String content,
         @Schema(description = "챌린지 타입", example = "DISTANCE")
         ChallengeCategory challengeCategory,
+        @Schema(description = "챌린지 이미지", example = "test.jpg")
+        String imageUrl,
         @Schema(description = "목표 수치", example = "100.0")
-        float targetValue,
+        String targetValue,
         @Schema(description = "챌린지 시작일자", example = "2024-06-01T00:00:00")
         LocalDateTime startDate,
         @Schema(description = "챌린지 종료일자", example = "2024-0.6-30T00:00:00")

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/challenge/response/CreateChallengeResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/challenge/response/CreateChallengeResponse.java
@@ -15,8 +15,10 @@ public record CreateChallengeResponse(
         String content,
         @Schema(description = "챌린지 타입", example = "DISTANCE")
         ChallengeCategory challengeCategory,
+        @Schema(description = "챌린지 이미지", example = "test.jpg")
+        String imageUrl,
         @Schema(description = "목표 수치", example = "100.0")
-        float targetValue,
+        String targetValue,
         @Schema(description = "챌린지 시작일자", example = "2024-06-01T00:00:00")
         LocalDateTime startDate,
         @Schema(description = "챌린지 종료일자", example = "2024-0.6-30T00:00:00")
@@ -28,6 +30,7 @@ public record CreateChallengeResponse(
                 challenge.getTitle(),
                 challenge.getContent(),
                 challenge.getChallengeCategory(),
+                challenge.getImageUrl(),
                 challenge.getTargetValue(),
                 challenge.getStartDate(),
                 challenge.getEndDate()

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/challenge/response/GetChallengeResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/challenge/response/GetChallengeResponse.java
@@ -15,18 +15,14 @@ public record GetChallengeResponse(
         String content,
         @Schema(description = "챌린지 타입", example = "DISTANCE")
         ChallengeCategory challengeCategory,
+        @Schema(description = "챌린지 이미지", example = "test.jpg")
+        String imageUrl,
         @Schema(description = "목표 수치", example = "100.0")
-        float targetValue,
+        String targetValue,
         @Schema(description = "챌린지 시작일자", example = "2024-06-01T00:00:00")
         LocalDateTime startDate,
         @Schema(description = "챌린지 종료일자", example = "2024-0.6-30T00:00:00")
-        LocalDateTime endDate,
-        @Schema(description = "누적 달린 시간", example = "26.4")
-        float totalRunningTime,
-        @Schema(description = "누적 소모 칼로리", example = "170.34352")
-        float totalKcal,
-        @Schema(description = "누적 평균 페이스 (분/km)", example = "4.66935")
-        float totalMeanPace
+        LocalDateTime endDate
 ) {
     public static GetChallengeResponse from(Challenge challenge) {
         return new GetChallengeResponse(
@@ -34,12 +30,10 @@ public record GetChallengeResponse(
                 challenge.getTitle(),
                 challenge.getContent(),
                 challenge.getChallengeCategory(),
+                challenge.getImageUrl(),
                 challenge.getTargetValue(),
                 challenge.getStartDate(),
-                challenge.getEndDate(),
-                challenge.getTotalRunningTime(),
-                challenge.getTotalKcal(),
-                challenge.getTotalMeanPace()
+                challenge.getEndDate()
         );
     }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/challenge/response/UpdateChallengeResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/challenge/response/UpdateChallengeResponse.java
@@ -15,8 +15,10 @@ public record UpdateChallengeResponse(
         String content,
         @Schema(description = "챌린지 타입", example = "DISTANCE")
         ChallengeCategory challengeCategory,
+        @Schema(description = "챌린지 이미지", example = "test.jpg")
+        String imageUrl,
         @Schema(description = "목표 수치", example = "100.0")
-        float targetValue,
+        String targetValue,
         @Schema(description = "챌린지 시작일자", example = "2024-06-01T00:00:00")
         LocalDateTime startDate,
         @Schema(description = "챌린지 종료일자", example = "2024-0.6-30T00:00:00")
@@ -28,6 +30,7 @@ public record UpdateChallengeResponse(
                 challenge.getTitle(),
                 challenge.getContent(),
                 challenge.getChallengeCategory(),
+                challenge.getImageUrl(),
                 challenge.getTargetValue(),
                 challenge.getStartDate(),
                 challenge.getEndDate()

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/memberchallenge/response/GetMyChallengeResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/memberchallenge/response/GetMyChallengeResponse.java
@@ -1,39 +1,51 @@
 package com.runninghi.runninghibackv2.application.dto.memberchallenge.response;
 
+import com.runninghi.runninghibackv2.domain.entity.Challenge;
 import com.runninghi.runninghibackv2.domain.entity.MemberChallenge;
+import com.runninghi.runninghibackv2.domain.enumtype.ChallengeCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
 
 public record GetMyChallengeResponse(
         @Schema(description = "나의 챌린지 Id", example = "1")
         Long memberChallengeId,
-        @Schema(description = "연관된 챌린지 Id", example = "1")
-        Long challengeNo,
         @Schema(description = "연관된 멤버 Id", example = "1")
         Long memberNo,
-        @Schema(description = "챌린지 시작 후 달린 거리", example = "10.528268")
-        float distance,
-        @Schema(description = "챌린지 시작 후 달린 시간", example = "43.46666")
-        float runningTime,
-        @Schema(description = "챌린지 시작 후 소모한 칼로리", example = "170.34352")
-        float kcal,
-        @Schema(description = "챌린지 시작 후 평균 속도", example = "0.214163")
-        float speed,
-        @Schema(description = "챌린지 시작 후 평균 페이스 (분/km)", example = "4.66935")
-        float meanPace,
-        @Schema(description = "챌린지 달성 여부", example = "true")
-        boolean status
+        @Schema(description = "연관된 챌린지 Id", example = "1")
+        Long challengeNo,
+        @Schema(description = "챌린지명", example = "1개월 내로 100km 달리기")
+        String title,
+        @Schema(description = "챌린지 상세정보", example = "목표 거리만큼 달려보세요")
+        String content,
+        @Schema(description = "챌린지 타입", example = "DISTANCE")
+        ChallengeCategory challengeCategory,
+        @Schema(description = "챌린지 이미지", example = "test.jpg")
+        String imageUrl,
+        @Schema(description = "목표 수치", example = "100.0")
+        String targetValue,
+        @Schema(description = "챌린지 시작일자", example = "2024-06-01T00:00:00")
+        LocalDateTime startDate,
+        @Schema(description = "챌린지 종료일자", example = "2024-0.6-30T00:00:00")
+        LocalDateTime endDate,
+        @Schema(description = "챌린지 시작 후 기록", example = "10.528268")
+        String record
 ) {
     public static GetMyChallengeResponse from(MemberChallenge memberChallenge) {
+        Challenge challenge = memberChallenge.getChallenge();
+
         return new GetMyChallengeResponse(
                 memberChallenge.getMemberChallengeId(),
-                memberChallenge.getChallenge().getChallengeNo(),
                 memberChallenge.getMember().getMemberNo(),
-                memberChallenge.getDistance(),
-                memberChallenge.getRunningTime(),
-                memberChallenge.getKcal(),
-                memberChallenge.getSpeed(),
-                memberChallenge.getMeanPace(),
-                memberChallenge.isStatus()
+                challenge.getChallengeNo(),
+                challenge.getTitle(),
+                challenge.getContent(),
+                challenge.getChallengeCategory(),
+                challenge.getImageUrl(),
+                challenge.getTargetValue(),
+                challenge.getStartDate(),
+                challenge.getEndDate(),
+                memberChallenge.getRecord()
         );
     }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/ChallengeService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/ChallengeService.java
@@ -28,6 +28,7 @@ public class ChallengeService {
                 .title(request.title())
                 .content(request.content())
                 .challengeCategory(request.challengeCategory())
+                .imageUrl(request.imageUrl())
                 .targetValue(request.targetValue())
                 .startDate(request.startDate())
                 .endDate(request.endDate())

--- a/src/main/java/com/runninghi/runninghibackv2/domain/entity/Challenge.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/entity/Challenge.java
@@ -38,8 +38,12 @@ public class Challenge extends BaseTimeEntity {
     private ChallengeCategory challengeCategory;
 
     @NotNull
+    @Comment("챌린지 이미지")
+    private String imageUrl;
+
+    @NotNull
     @Comment("목표 수치")
-    private float targetValue;
+    private String targetValue;
 
     @Comment("챌린지 시작일자")
     private LocalDateTime startDate;
@@ -47,34 +51,27 @@ public class Challenge extends BaseTimeEntity {
     @Comment("챌린지 종료일자")
     private LocalDateTime endDate;
 
-    @Comment("누적 달린 시간")
-    private float totalRunningTime;
+    @Comment("챌린지 활성화 상태")
+    private boolean status;
 
-    @Comment("누적 소모 칼로리")
-    private float totalKcal;
-
-    @Comment("누적 평균 페이스 (분/km)")
-    private float totalMeanPace;
-
-    @OneToMany(mappedBy = "challenge")
+    @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @Comment("챌린지에 참여한 멤버 리스트")
     @JsonIgnore
     private List<MemberChallenge> participants;
 
     @Builder
     public Challenge(Long challengeNo, String title, String content, ChallengeCategory challengeCategory,
-                     float targetValue, LocalDateTime startDate, LocalDateTime endDate,
-                     float totalRunningTime, float totalKcal, float totalMeanPace, List<MemberChallenge> participants) {
+                     String imageUrl, String targetValue, LocalDateTime startDate, LocalDateTime endDate,
+                     boolean status, List<MemberChallenge> participants) {
         this.challengeNo = challengeNo;
         this.title = title;
         this.content = content;
         this.challengeCategory = challengeCategory;
+        this.imageUrl = imageUrl;
         this.targetValue = targetValue;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.totalRunningTime = totalRunningTime;
-        this.totalKcal = totalKcal;
-        this.totalMeanPace = totalMeanPace;
+        this.status = status;
         this.participants = participants;
     }
 
@@ -82,6 +79,7 @@ public class Challenge extends BaseTimeEntity {
         this.title = request.title();
         this.content = request.content();
         this.challengeCategory = request.challengeCategory();
+        this.imageUrl = request.imageUrl();
         this.targetValue = request.targetValue();
         this.startDate = request.startDate();
         this.endDate = request.endDate();

--- a/src/main/java/com/runninghi/runninghibackv2/domain/entity/MemberChallenge.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/entity/MemberChallenge.java
@@ -33,11 +33,11 @@ public class MemberChallenge extends BaseTimeEntity {
     private String record;
 
     @Builder
-    public MemberChallenge(Long memberChallengeId, Challenge challenge, Member member, String record) {
+    public MemberChallenge(Long memberChallengeId, Challenge challenge, Member member) {
         this.memberChallengeId = memberChallengeId;
         this.challenge = challenge;
         this.member = member;
-        this.record = record;
+        this.record = "0";
     }
 
     public void updateRecord(GpsDataVO gpsDataVO) {

--- a/src/main/java/com/runninghi/runninghibackv2/domain/entity/MemberChallenge.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/entity/MemberChallenge.java
@@ -40,5 +40,22 @@ public class MemberChallenge extends BaseTimeEntity {
         this.record = record;
     }
 
+    public void updateRecord(GpsDataVO gpsDataVO) {
+        ChallengeCategory challengeCategory = this.challenge.getChallengeCategory();
+        float floatRecord = Float.parseFloat(this.record);
 
+        if(challengeCategory == ChallengeCategory.DISTANCE) {
+            this.record = String.valueOf(floatRecord + gpsDataVO.getDistance());
+        }
+
+        if(challengeCategory == ChallengeCategory.SPEED) {
+            this.record = String.valueOf(floatRecord + gpsDataVO.getSpeed());
+        }
+    }
+
+    public void updateRecord() {
+        int intRecord = Integer.parseInt(this.record);
+
+        this.record = String.valueOf(intRecord + 1);
+    }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/domain/entity/MemberChallenge.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/entity/MemberChallenge.java
@@ -49,7 +49,8 @@ public class MemberChallenge extends BaseTimeEntity {
         }
 
         if(challengeCategory == ChallengeCategory.SPEED) {
-            this.record = String.valueOf(floatRecord + gpsDataVO.getSpeed());
+            floatRecord = floatRecord == 0 ? gpsDataVO.getMeanPace() : (floatRecord + gpsDataVO.getMeanPace()) / 2;
+            this.record = String.valueOf(floatRecord);
         }
     }
 

--- a/src/main/java/com/runninghi/runninghibackv2/domain/entity/MemberChallenge.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/entity/MemberChallenge.java
@@ -29,54 +29,16 @@ public class MemberChallenge extends BaseTimeEntity {
     @Comment("챌린지에 참여한 멤버")
     private Member member;
 
-    @Comment("챌린지 시작 후 달린 거리")
-    private float distance;
-
-    @Comment("챌린지 시작 후 달린 시간")
-    private float runningTime;
-
-    @Comment("챌린지 시작 후 소모 칼로리")
-    private float kcal;
-
-    @Comment("챌린지 시작 후 평균 속도")
-    private float speed;
-
-    @Comment("챌린지 시작 후 평균 페이스 (분/km)")
-    private float meanPace;
-
-    @Comment("챌린지 달성 여부")
-    private boolean status;
+    @Comment("챌린지 시작 후 누적 기록")
+    private String record;
 
     @Builder
-    public MemberChallenge(Long memberChallengeId, Challenge challenge, Member member, float distance, float runningTime,
-                           float kcal, float speed, float meanPace, boolean status) {
+    public MemberChallenge(Long memberChallengeId, Challenge challenge, Member member, String record) {
         this.memberChallengeId = memberChallengeId;
         this.challenge = challenge;
         this.member = member;
-        this.distance = distance;
-        this.runningTime = runningTime;
-        this.kcal = kcal;
-        this.speed = speed;
-        this.meanPace = meanPace;
-        this.status = status;
+        this.record = record;
     }
 
-    public void updateRecord(GpsDataVO gpsDataVO) {
-        this.distance += gpsDataVO.getDistance();
-        this.runningTime += gpsDataVO.getTime();
-        this.kcal += gpsDataVO.getKcal();
-        this.speed = this.speed == 0 ? gpsDataVO.getSpeed() : (speed + gpsDataVO.getSpeed()) / 2;
-        this.meanPace = this.meanPace == 0 ? gpsDataVO.getMeanPace() : (meanPace + gpsDataVO.getMeanPace()) / 2;
 
-        checkAndUpdateStatus(this.challenge.getChallengeCategory(), this.challenge.getTargetValue());
-    }
-
-    private void checkAndUpdateStatus(ChallengeCategory challengeCategory, float targetValue) {
-        float value = 0;
-        if(challengeCategory == ChallengeCategory.DISTANCE) value = this.distance;
-        if(challengeCategory == ChallengeCategory.SPEED) value = this.speed;
-        // if(challengeCategory == ChallengeCategory.ATTENDANCE)
-
-        this.status = value >= targetValue ? true : false;
-    }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/domain/repository/PostRepository.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/repository/PostRepository.java
@@ -1,13 +1,17 @@
 package com.runninghi.runninghibackv2.domain.repository;
 
 import com.runninghi.runninghibackv2.domain.entity.Member;
+import com.runninghi.runninghibackv2.domain.entity.MemberChallenge;
 import com.runninghi.runninghibackv2.domain.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -16,4 +20,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByReportCntIsGreaterThan(int reportCnt, Pageable pageable);
 
     List<Post> findAllByMember(Member deactivateMember);
+
+    Optional<Post> findFirstByMemberAndCreateDateBetween(Member member, LocalDateTime startDate, LocalDateTime endDate);
 }


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

* closed #332 
* closed #334 


## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- Challenge 엔티티의 targetValue(목표 수치) 컬럼 String 타입으로 변경, 이미지 컬럼 추가
- MemberChallenge 엔티티의 record(기록) 컬럼 String 타입으로 변경
- String 타입으로 변경됨에 따라 챌린지 타입(거리, 속도, 출석)에 상관 없이 targetValue라는 한 가지 컬럼만을 사용함.
- 러닝 기록(post) 생성 시 MemberChallenge의 record가 업데이트되는 방식 변경
    

      - 기존에 distance, speed, meanPace 등으로 분리되어 있던 컬럼을 record 한 가지 컬럼으로 통일.
      - String 타입인 record를 float으로 파싱하여 GpsData의 float값을 더하여 누적하는 방식으로 변경.
      - 챌린지 타입에 따라 GpsData에서 다른 값을 꺼내서 record에 누적.
        챌린지 타입이 '거리'인 경우: distance값 누적
        챌린지 타입이 '속도'인 경우: meanPace의 평균값 누적
        챌린지 타입이 '출석'인 경우: 하루동안 러닝 기록이 있는 경우 1 증가(하루에 한번만 증가)
                  
- 현재 챌린지 타입에서 '출석'과 '횟수'를 동일한 개념으로 사용하고 있는데, 필요 시 '횟수' 챌린지 타입 생성 가능

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
챌린지 타입에서 '출석'과 '횟수' 타입을 분리해야 할 지?
챌린지 목표 달성 이후에도 기록이 누적되어야 할 지?

