### PR TITLE
[#371] 도커 컨테이너를 활용한 CI/CD 배포 설정

### DIFF
--- a/.github/workflows/pr-build-gradle.yml
+++ b/.github/workflows/pr-build-gradle.yml
@@ -58,9 +58,35 @@ jobs:
           mkdir -p ./src/main/resources/firebase
           mv ./runninghi-firebase-adminsdk.json ./src/main/resources/firebase/
 
+      ## apple 설정
+      - name: apple setting
+        run: |
+          mkdir -p ./src/main/resources/apple
+          touch ./src/main/resources/apple/Apple_AuthKey.p8
+          echo "${{ secrets.APPLE_AUTHKEY }}" > ./src/main/resources/apple/Apple_AuthKey.p8
 
       - name: Add permission to make gradlew executable
         run: chmod +x gradlew
 
       - name: Test with Gradle
         run: ./gradlew --info test
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: build
+
+      ## docker upload image
+      - name: docker image build
+        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/runninghi-dev .
+
+      # DockerHub Login
+      - name: docker login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Docker Hub push
+      - name: docker Hub push
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/runninghi-dev

--- a/.github/workflows/push-deploy-gradle.yml
+++ b/.github/workflows/push-deploy-gradle.yml
@@ -8,100 +8,33 @@ permissions:
   contents: read
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      ## MySQL 환경을 테스트 환경에서 설정합니다.
-      - name: Setup MySQL
-        uses: samin/mysql-action@v1
-        with:
-          character set server: 'utf8'
-          mysql database: 'runninghi'
-          mysql user: ${{ secrets.MYSQL_USERNAME }}
-          mysql password: ${{ secrets.MYSQL_PASSWORD }}
-
-      ## resources 디렉토리 확인 및 생성, application.yml 설정
-      - name: Setup application.yml
-        run: |
-          mkdir -p ./src/main/resources
-          touch ./src/main/resources/application.yml
-          echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application.yml
-        shell: bash
-
-      ## firebase sdk 설정
-      - name: create-json
-        id: create-json
-        uses: jsdaniell/create-json@v1.2.3
-        with:
-          name: "runninghi-firebase-adminsdk.json"
-          json: ${{ secrets.FIREBASE_SDK }}
-
-      ## firebase 디렉토리 생성 및 JSON 파일 이동
-      - name: Setup Firebase Directory and Move JSON
-        run: |
-          mkdir -p ./src/main/resources/firebase
-          mv ./runninghi-firebase-adminsdk.json ./src/main/resources/firebase/
-
-      ## apple 설정
-      - name: apple setting
-        run: |
-          mkdir -p ./src/main/resources/apple
-          touch ./src/main/resources/apple/Apple_AuthKey.p8
-          echo "${{ secrets.APPLE_AUTHKEY }}" > ./src/main/resources/apple/Apple_AuthKey.p8
-
-      - name: Add permission to make gradlew executable
-        run: chmod +x gradlew
-
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
-        with:
-          arguments: build
-
-      # build 된 jar 파일을 업로드합니다.
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: cicd
-          path: build/libs/*.jar
-
   deploy:
-    needs: build
     runs-on: ubuntu-latest
 
     steps:
-      # artifact에서 jar파일을 다운로드 받습니다.
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: cicd
-          path: build/libs
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       # 서버에 통신하기 위한 SSH를 설정합니다.
       - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.5.4
+        uses: appleboy/ssh-action@v0.1.8
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      # 배포 서버에 host 키 확인
-      - name: Add remote server to known hosts
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan ${{ secrets.DEV_SERVER_HOST }} >> ~/.ssh/known_hosts
-
-      # 서버에 jar파일을 보내기 위해 scp 명령어를 사용합니다.
-      - name: SCP transfer
-        run: scp ./build/libs/*.jar ${{ secrets.DEV_SERVER_USERNAME }}@${{ secrets.DEV_SERVER_HOST }}:/home/ubuntu
-
-      # 서버 원격으로 명령어를 실행합니다. 서버 포트를 확인하고 실행중이면 종료합니다. 빌도된 jar파일을 실행합니다.
-      - name: Execute remote commands
-        run: |
-          ssh ${{ secrets.DEV_SERVER_USERNAME }}@${{ secrets.DEV_SERVER_HOST }} "sudo fuser -k ${{ secrets.DEV_SERVER_PORT }}/tcp || true; nohup sudo java -jar ./*.jar > nohup.out 2>&1 &"
+          host: ${{ secrets.DEV_SERVER_HOST }}
+          username: ${{ secrets.DEV_SERVER_USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            # 배포 서버에 host 키 확인
+            sudo mkdir -p ~/.ssh
+            sudo ssh-keyscan ${{ secrets.DEV_SERVER_HOST }} >> ~/.ssh/known_hosts
+            
+            # 배포 서버에서 DockerHub Login
+            sudo docker login -u ${{ secrets.DOCKERHUN_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+            
+            # Pull Docker Image
+            sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/runninghi-dev:latest
+            
+            # Stop and Remove existing contrainer
+            sudo docker stop runninghi-dev || true && docker rm runninghi-dev || true
+            
+            # Run new container
+            sudo docker run -d --name runninghi-dev -p ${{ secrets.DEV_SERVER_PORT }}:8080 ${{ secrets.DOCKERHUB_USERNAME }}/runninghi-dev:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Docker file for Dev
+
+# jdk 17 Image Start
+FROM openjdk:17-jdk
+
+# Set the working directory
+WORKDIR /app
+
+# Log 파일 저장 디렉토리 생성
+RUN mkdir -p /app/logs
+
+# 인자 정리 -jar
+ARG JAR_FILE=build/libs/*.jar
+
+# jar File Copy
+COPY ${JAR_FILE} app.jar
+
+# jar 파일 실행 및 로그 입출력 지정 명령
+ENTRYPOINT ["sh", "-c", "java -jar app.jar > /app/logs/app.log 2>&1"]

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/bookmark/response/CreateBookmarkResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/bookmark/response/CreateBookmarkResponse.java
@@ -6,9 +6,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "북마크 생성 응답")
 public record CreateBookmarkResponse(
 
-        @Schema(description = "회원 번호")
+        @Schema(description = "요청한 회원 번호")
         Long memberNo,
-        @Schema(description = "게시글 번호")
+        @Schema(description = "북마크된 게시글 번호")
         Long postNo
 ) {
 

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/reply/response/GetReplyListResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/reply/response/GetReplyListResponse.java
@@ -13,7 +13,7 @@ public class GetReplyListResponse {
 
         @Schema(description = "댓글 번호", example = "2")
         Long replyNo;
-        @Schema(description = "댓글 작성자 Id", example = "1")
+        @Schema(description = "댓글 작성자 번호", example = "1")
         Long memberNo;
         @Schema(description = "댓글 작성자 닉네임", example = "러너1")
         String memberName;
@@ -29,7 +29,7 @@ public class GetReplyListResponse {
         Boolean isOwner = false;
         @Schema(description = "댓글 생성 일", example = "2024-03-27T13:23:12")
         LocalDateTime createDate;
-        @Schema(description = "댓글 수정 일", example = "2024-03-27T13:23:12")
+        @Schema(description = "댓글 수정 여부", example = "false")
         Boolean isUpdated;
 
     public GetReplyListResponse(Long replyNo, Long memberNo, String memberName, Long postNo, String replyContent, int reportedCount, boolean isDeleted, LocalDateTime createDate, LocalDateTime updateDate) {


### PR DESCRIPTION
## 📌 관련 이슈
- closed #371 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- 기존 CI/CD 배포 과정에선 `artifact`를 사용중이었습니다.
- `dev` 브랜치에 pr을 생성/push 시에 빌드/빌드+배포 를 자동화하였습니다.
- `artifact`환경을 공유하는 건 같은 `yml`파일에서만 가능하기 때문에 `push`이벤트에 다시 한번 프로젝트를 빌드하므로 불필요한 프로세스를 거칩니다.
- 이를 해결하기 위해 jar 파일을 도커 컨테이너에 올리고, 이를 도커환경에서 운영하도록 설정하였습니다. 

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

<br>
<br>

**PR Title 형식 예시**

```
[Feature - Feb 1st, 2024]{USER} 엔티티 설계
```
