### PR TITLE
Refactor/#401 - 애플 로그인 로직 수정

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
@@ -156,11 +156,14 @@ public class MemberController {
     })
     public ResponseEntity<ApiResult<CreateMemberResponse>> appleLogin(@RequestBody AppleLoginRequest request) {
 
+        // clientSecret 생성
         String clientSecret = appleOauthService.createClientSecret();
 
+        // authorizationCode와 clientSecret으로 refreshToken 가져오기
         AppleTokenResponse appleTokenResponse = appleOauthService.getAppleToken(request.authorizationCode(), clientSecret);
 
-        Map<String, String> memberResponse = appleOauthService.appleOauth(request, appleTokenResponse);
+        // 클라이언트에서 전달받은 identityToken 검증, 회원가입/로그인 처리
+        Map<String, String> memberResponse = appleOauthService.appleOauth(request.identityToken(), appleTokenResponse);
 
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", memberResponse.get("accessToken"));

--- a/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
@@ -158,9 +158,9 @@ public class MemberController {
 
         String clientSecret = appleOauthService.createClientSecret();
 
-//        AppleTokenResponse appleTokenResponse = appleOauthService.getAppleToken(request.identityToken(), clientSecret);
+        AppleTokenResponse appleTokenResponse = appleOauthService.getAppleToken(request.authorizationCode(), clientSecret);
 
-        Map<String, String> memberResponse = appleOauthService.appleOauth(request);
+        Map<String, String> memberResponse = appleOauthService.appleOauth(request, appleTokenResponse);
 
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", memberResponse.get("accessToken"));

--- a/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
@@ -163,7 +163,7 @@ public class MemberController {
         AppleTokenResponse appleTokenResponse = appleOauthService.getAppleToken(request.authorizationCode(), clientSecret);
 
         // 클라이언트에서 전달받은 identityToken 검증, 회원가입/로그인 처리
-        Map<String, String> memberResponse = appleOauthService.appleOauth(request.identityToken(), appleTokenResponse);
+        Map<String, String> memberResponse = appleOauthService.appleOauth(request, appleTokenResponse);
 
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", memberResponse.get("accessToken"));

--- a/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
@@ -158,9 +158,9 @@ public class MemberController {
 
         String clientSecret = appleOauthService.createClientSecret();
 
-        AppleTokenResponse appleTokenResponse = appleOauthService.getAppleToken(request.authorizationCode(), clientSecret);
+//        AppleTokenResponse appleTokenResponse = appleOauthService.getAppleToken(request.identityToken(), clientSecret);
 
-        Map<String, String> memberResponse = appleOauthService.appleOauth(appleTokenResponse, request.nonce());
+        Map<String, String> memberResponse = appleOauthService.appleOauth(request);
 
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", memberResponse.get("accessToken"));

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/member/request/AppleLoginRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/member/request/AppleLoginRequest.java
@@ -3,6 +3,6 @@ package com.runninghi.runninghibackv2.application.dto.member.request;
 
 public record AppleLoginRequest(
         String identityToken,
-        String refreshToken
+        String authorizationCode
 ) {
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/member/request/AppleLoginRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/member/request/AppleLoginRequest.java
@@ -2,7 +2,7 @@ package com.runninghi.runninghibackv2.application.dto.member.request;
 
 
 public record AppleLoginRequest(
-        String authorizationCode,
-        String nonce
+        String identityToken,
+        String refreshToken
 ) {
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/member/response/AppleTokenResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/member/response/AppleTokenResponse.java
@@ -4,9 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record AppleTokenResponse(
         @JsonProperty("access_token") String accessToken,
-        @JsonProperty("id_token") String idToken,
-        @JsonProperty("refresh_token") String refreshToken,
-        @JsonProperty("expires_in") Long expiresIn,
-        @JsonProperty("token_type") String tokenType
+        @JsonProperty("refresh_token") String refreshToken
 ) {
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/AppleOauthService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/AppleOauthService.java
@@ -1,5 +1,6 @@
 package com.runninghi.runninghibackv2.application.service;
 
+import com.runninghi.runninghibackv2.application.dto.member.request.AppleLoginRequest;
 import com.runninghi.runninghibackv2.application.dto.member.response.AppleTokenResponse;
 import com.runninghi.runninghibackv2.auth.apple.*;
 import com.runninghi.runninghibackv2.auth.jwt.JwtTokenProvider;
@@ -68,9 +69,9 @@ public class AppleOauthService {
 
     // apple user 생성
     @Transactional
-    public Map<String, String> appleOauth(String identityToken, AppleTokenResponse appleTokenResponse) {
+    public Map<String, String> appleOauth(AppleLoginRequest request, AppleTokenResponse appleTokenResponse) {
         // identity_token의 header를 추출
-        Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(identityToken);
+        Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(request.identityToken());
 
         // identity_token을 검증하기 위해 애플의 publicKey list 요청
         ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
@@ -80,7 +81,7 @@ public class AppleOauthService {
         PublicKey publicKey = applePublicKeyGenerator.generate(appleTokenHeader, applePublicKeys);
 
         // identity_token을 publicKey로 검증하여 claim 추출 : 서명 검증
-        Claims claims = appleTokenParser.extractClaims(identityToken, publicKey);
+        Claims claims = appleTokenParser.extractClaims(request.identityToken(), publicKey);
 
         // iss, aud, exp, 검증
         if (!appleClaimsValidator.isValid(claims)) {

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/AppleOauthService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/AppleOauthService.java
@@ -69,7 +69,7 @@ public class AppleOauthService {
 
     // apple user 생성
     @Transactional
-    public Map<String, String> appleOauth(AppleLoginRequest request) {
+    public Map<String, String> appleOauth(AppleLoginRequest request, AppleTokenResponse appleTokenResponse) {
         // id_token의 header를 추출
         Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(request.identityToken());
 
@@ -93,7 +93,7 @@ public class AppleOauthService {
         Optional<Member> optionalMember = memberRepository.findByAppleId(appleResponse.get("sub"));
 
         return optionalMember.map(this::loginWithApple)
-                .orElseGet(() -> loginWithAppleCreateMember(appleResponse, request.refreshToken()));
+                .orElseGet(() -> loginWithAppleCreateMember(appleResponse, appleTokenResponse.refreshToken()));
     }
 
     // id-token에서 sub, name 추출

--- a/src/main/java/com/runninghi/runninghibackv2/auth/apple/AppleClaimsValidator.java
+++ b/src/main/java/com/runninghi/runninghibackv2/auth/apple/AppleClaimsValidator.java
@@ -10,14 +10,14 @@ import java.util.Date;
 public class AppleClaimsValidator {
 
     private final String iss;
-    private final String clientId;
+    private final String bundleId;
 
     public AppleClaimsValidator(
             @Value("${apple.iss}") String iss,
-            @Value("${apple.client-id}") String clientId
+            @Value("${apple.bundle-id}") String bundleId
     ) {
         this.iss = iss;
-        this.clientId = clientId;
+        this.bundleId = bundleId;
     }
 
     public boolean isValid(Claims claims) {
@@ -27,6 +27,6 @@ public class AppleClaimsValidator {
 
         return currentDate.before(expiration) &&
                 claims.getIssuer().contains(iss) &&
-                claims.getAudience().equals(clientId);
+                claims.getAudience().equals(bundleId); // 앱의 bundle id
     }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/auth/apple/AppleClaimsValidator.java
+++ b/src/main/java/com/runninghi/runninghibackv2/auth/apple/AppleClaimsValidator.java
@@ -20,14 +20,13 @@ public class AppleClaimsValidator {
         this.clientId = clientId;
     }
 
-    public boolean isValid(Claims claims, String nonce) {
-        // exp, nonce, iss, aud 검증
+    public boolean isValid(Claims claims) {
+        // exp, iss, aud 검증
         Date expiration = claims.getExpiration();
         Date currentDate = new Date();
 
         return currentDate.before(expiration) &&
                 claims.getIssuer().contains(iss) &&
-                claims.getAudience().equals(clientId) &&
-                claims.get("nonce").equals(nonce);
+                claims.getAudience().equals(clientId);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈 #401 

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

- closed #401

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- 기존의 로그인 방식은 RESTApi를 사용한 방식으로, 백엔드에서 애플 측으로 identity_token을 요청하고 처리하는 방식이지만 iOS에서는 프론트엔드에서 애플 측으로 identity_token을 요청하고 그 값을 백엔드로 전달하기 때문에 전체적인 로직을 수정


