### PR TITLE
[#432] Refactoring - 챌린지 상세조회, 나의 챌린지 상세조회 API 분리

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/controller/ChallengeController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/controller/ChallengeController.java
@@ -66,24 +66,19 @@ public class ChallengeController {
     }
 
     /**
-     * 랭킹을 포함한 챌린지 상세 정보를 조회합니다.
+     * 챌린지 상세 정보를 조회합니다.
      * 랭킹 조회 시 전체 회원의 러닝 순위를 조회합니다. 기록이 높을수록 높은 순위를 부여합니다.
      * 동일한 값이 있을 경우 동일한 순위를 부여하고 다음 순위를 건너뜁니다.
-     * @return 참여중인 챌린지인지 여부에 따라 return 값이 다릅니다.
-     *         참여하지 않은 챌린지인 경우 Challenge 기본 정보가 반환됩니다.
-     *         참여중인 챌린지인 경우 기록 및 나의 순위 정보를 포함한 Challenge 정보가 반환됩니다.
+     * @return  전체 회원 랭킹을 포함한 Challenge 기본 정보가 반환됩니다.
      * @apiNote 이 메서드를 사용하기 위해서는 요청 헤더에 유효한 Bearer 토큰이 포함되어야 합니다.
      *          토큰이 유효하지 않거나, 토큰에 해당하는 사용자가 존재하지 않을 경우 접근이 거부됩니다.
      */
     @Operation(summary = "챌린지 상세 조회", description = "챌린지 상세 정보를 조회합니다.")
     @GetMapping("/{challengeNo}")
-    public ResponseEntity<ApiResult<ChallengeResponse>> getChallengeById(
-            @PathVariable Long challengeNo,
-            @RequestHeader(name = "Authorization") String bearerToken) {
+    public ResponseEntity<ApiResult<GetChallengeResponse>> getChallengeById(
+            @PathVariable Long challengeNo) {
 
-        Long memberNo = jwtTokenProvider.getMemberNoFromToken(bearerToken);
-
-        ChallengeResponse response = challengeService.getChallengeById(challengeNo, memberNo);
+        GetChallengeResponse response = challengeService.getChallengeById(challengeNo);
 
         return ResponseEntity.ok(ApiResult.success("챌린지 상세 조회 성공", response));
     }
@@ -146,26 +141,27 @@ public class ChallengeController {
         return ResponseEntity.ok(ApiResult.success("나의 챌린지 전체 조회 성공", response));
     }
 
-//    /**
-//     * 회원이 참여한 챌린지 데이터입니다.
-//     * 랭킹을 포함한 나의 챌린지 상세 정보를 조회합니다.
-//     * 전체 회원 랭킹과 로그인한 회원의 랭킹을 조회합니다. 기록이 높을수록 높은 순위를 부여합니다.
-//     * 동일한 값이 있을 경우 동일한 순위를 부여하고 다음 순위를 건너뜁니다.
-//     * @return 랭킹을 포함한 Challenge 데이터를 반환합니다.
-//     * @apiNote 이 메서드를 사용하기 위해서는 요청 헤더에 유효한 Bearer 토큰이 포함되어야 합니다.
-//     *          토큰이 유효하지 않거나, 토큰에 해당하는 사용자가 존재하지 않을 경우 접근이 거부됩니다.
-//     */
-//    @Operation(summary = "나의 챌린지 상세 조회", description = "로그인한 사용자가 참여중인 챌린지 목록 화면에서 " +
-//            "선택한 챌린지의 정보를 조회합니다.")
-//    @GetMapping("/my-challenge/{myChallengeNo}")
-//    public ResponseEntity<ApiResult<GetMyChallengeResponse>> getMyChallengeById(
-//            @PathVariable Long myChallengeNo,
-//            @RequestHeader(name = "Authorization") String bearerToken) {
-//
-//        Long memberNo = jwtTokenProvider.getMemberNoFromToken(bearerToken);
-//
-//        GetMyChallengeResponse response = myChallengeService.getMyChallengeById(memberNo, myChallengeNo);
-//
-//        return ResponseEntity.ok(ApiResult.success("나의 챌린지 상세 조회 성공", response));
-//    }
+    /**
+     * 회원이 참여한 챌린지 데이터입니다.
+     * challengeNo와 memberNo로 MemberChallenge 데이터를 조회합니다.
+     * 회원 랭킹을 포함한 나의 챌린지 상세 정보를 조회합니다.
+     * 전체 회원 랭킹과 로그인한 회원의 랭킹을 조회합니다. 기록이 높을수록 높은 순위를 부여합니다.
+     * 동일한 값이 있을 경우 동일한 순위를 부여하고 다음 순위를 건너뜁니다.
+     * @return 회원의 기록, 랭킹을 포함한 Challenge 데이터를 반환합니다.
+     * @apiNote 이 메서드를 사용하기 위해서는 요청 헤더에 유효한 Bearer 토큰이 포함되어야 합니다.
+     *          토큰이 유효하지 않거나, 토큰에 해당하는 사용자가 존재하지 않을 경우 접근이 거부됩니다.
+     */
+    @Operation(summary = "나의 챌린지 상세 조회", description = "로그인한 사용자가 참여중인 챌린지 목록 화면에서 " +
+            "선택한 챌린지의 정보를 조회합니다.")
+    @GetMapping("/my-challenge/{challengeNo}")
+    public ResponseEntity<ApiResult<GetMyChallengeResponse>> getMyChallengeById(
+            @PathVariable Long challengeNo,
+            @RequestHeader(name = "Authorization") String bearerToken) {
+
+        Long memberNo = jwtTokenProvider.getMemberNoFromToken(bearerToken);
+
+        GetMyChallengeResponse response = myChallengeService.getMyChallengeByChallengeId(memberNo, challengeNo);
+
+        return ResponseEntity.ok(ApiResult.success("나의 챌린지 상세 조회 성공", response));
+    }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/ChallengeService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/ChallengeService.java
@@ -57,25 +57,13 @@ public class ChallengeService {
     }
 
     @Transactional(readOnly = true)
-    public ChallengeResponse getChallengeById(Long challengeNo, Long memberNo) {
+    public GetChallengeResponse getChallengeById(Long challengeNo) {
 
         Challenge challenge = challengeRepository.findById(challengeNo)
                 .orElseThrow(EntityNotFoundException::new);
 
-        Member member = memberRepository.findByMemberNo(memberNo);
-
         List<GetChallengeRankingResponse> challengeRanking =
                 memberChallengeRepository.findChallengeRanking(challenge.getChallengeNo());
-
-        Optional<MemberChallenge> memberChallenge =
-                memberChallengeRepository.findByMemberAndChallenge(member, challenge);
-
-        if(memberChallenge.isPresent()) {
-            GetChallengeRankingResponse memberRanking =
-                    memberChallengeRepository.findMemberRanking(challengeNo, memberNo);
-
-            return GetMyChallengeResponse.from(memberChallenge.get(), challengeRanking, memberRanking);
-        }
 
         return GetChallengeResponse.from(challenge, challengeRanking);
     }

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/MyChallengeService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/MyChallengeService.java
@@ -60,11 +60,14 @@ public class MyChallengeService {
     }
 
     @Transactional(readOnly = true)
-    public GetMyChallengeResponse getMyChallengeById(Long memberNo, Long myChallengeNo) {
+    public GetMyChallengeResponse getMyChallengeByChallengeId(Long memberNo, Long challengeNo) {
 
-        MemberChallenge myChallenge = memberChallengeRepository.findById(myChallengeNo)
+        Member member = memberRepository.findByMemberNo(memberNo);
+        Challenge challenge = challengeRepository.findById(challengeNo)
                 .orElseThrow(EntityNotFoundException::new);
-        Long challengeNo = myChallenge.getChallenge().getChallengeNo();
+
+        MemberChallenge myChallenge = memberChallengeRepository.findByMemberAndChallenge(member, challenge)
+                .orElseThrow(EntityNotFoundException::new);
 
         List<GetChallengeRankingResponse> challengeRanking = memberChallengeRepository.findChallengeRanking(challengeNo);
         GetChallengeRankingResponse memberRanking = memberChallengeRepository.findMemberRanking(challengeNo, memberNo);


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

- closed #432 

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- 어제 원래 분리되어 있던 두 API를 통합하는 걸로 변경했었는데 
  response 타입이 달라지는 문제가 발생하여 다시 분리하기로 했습니다.
  그리고 기존에 나의 챌린지 상세조회 API 파라미터가 memberChallengeNo로 되어있어
  챌린지에서 참여하기를 누른 후 나의챌린지 화면으로 전환이 될 때,
  challengeNo로 나의챌린지 상세조회 API를 호출하는 경우 상관없는 나의챌린지가 조회되어서 
  나의 챌린지 상세조회 시 파라미터를 변경했어요 memberChallengeNo -> challengeNo
