### PR TITLE
[#436] bugfix : identityToken -> identityCode로 변수명 수정

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/controller/MemberController.java
@@ -162,7 +162,7 @@ public class MemberController {
         // authorizationCode와 clientSecret으로 refreshToken 가져오기
         AppleTokenResponse appleTokenResponse = appleOauthService.getAppleToken(request.authorizationCode(), clientSecret);
 
-        // 클라이언트에서 전달받은 identityToken 검증, 회원가입/로그인 처리
+        // 클라이언트에서 전달받은 identityCode 검증, 회원가입/로그인 처리
         Map<String, String> memberResponse = appleOauthService.appleOauth(request, appleTokenResponse);
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/member/request/AppleLoginRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/member/request/AppleLoginRequest.java
@@ -2,7 +2,7 @@ package com.runninghi.runninghibackv2.application.dto.member.request;
 
 
 public record AppleLoginRequest(
-        String identityToken,
+        String identityCode,
         String authorizationCode
 ) {
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/AppleOauthService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/AppleOauthService.java
@@ -71,7 +71,7 @@ public class AppleOauthService {
     @Transactional
     public Map<String, String> appleOauth(AppleLoginRequest request, AppleTokenResponse appleTokenResponse) {
         // identity_token의 header를 추출
-        Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(request.identityToken());
+        Map<String, String> appleTokenHeader = appleTokenParser.parseHeader(request.identityCode());
 
         // identity_token을 검증하기 위해 애플의 publicKey list 요청
         ApplePublicKeys applePublicKeys = appleClient.getApplePublicKeys();
@@ -81,7 +81,7 @@ public class AppleOauthService {
         PublicKey publicKey = applePublicKeyGenerator.generate(appleTokenHeader, applePublicKeys);
 
         // identity_token을 publicKey로 검증하여 claim 추출 : 서명 검증
-        Claims claims = appleTokenParser.extractClaims(request.identityToken(), publicKey);
+        Claims claims = appleTokenParser.extractClaims(request.identityCode(), publicKey);
 
         // iss, aud, exp, 검증
         if (!appleClaimsValidator.isValid(claims)) {


### PR DESCRIPTION
## 📌 관련 이슈 #436

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

- closed #436 

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

**클라이언트에서 애플 로그인 시 오류 발생**

1.  포스트맨 상으로는 이미 사용된 authorizationCode라고 떴습니다.
    * 이미 iOS에 요청을 보내서 사용된 authorizationCode를 postman으로 사용하려고해서 뜬 메세지였습니다.
    * 현재 발생한 오류와 직접적으로 연관된 오류가 아니어서 다른 방법을 찾아봤습니다.
2. 직접 xcode로 simulator를 돌리고 서버 console을 확인해보니 idToken이 null이라서 parsing할 수 없다는 메세지가 떴습니다.

**확인 결과, 프론트에서는 ```identityCode``` 로 전달하고 있었고, 백에서는 ```identityToken```으로 받고 있었습니다. 
변수명을 identityCode로 수정하여 해결했습니다.** 

