### PR TITLE
[#522] 기본 프로필 이미지 설정 & 프로필 이미지 수정 추가

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/member/response/DeleteProfileImageResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/member/response/DeleteProfileImageResponse.java
@@ -1,0 +1,12 @@
+package com.runninghi.runninghibackv2.application.dto.member.response;
+
+import com.runninghi.runninghibackv2.domain.entity.Member;
+
+public record DeleteProfileImageResponse(
+        Long memberNo,
+        String profileImageUrl
+) {
+    public static DeleteProfileImageResponse of(Member member) {
+        return new DeleteProfileImageResponse(member.getMemberNo(), member.getProfileImageUrl());
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/member/response/GetMemberResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/member/response/GetMemberResponse.java
@@ -9,6 +9,8 @@ public record GetMemberResponse(
         Long memberNo,
         @Schema(description = "닉네임", example = "러너 23139403")
         String nickname,
+        @Schema(description = "프로필 이미지", example = "https://firebase...")
+        String profileImageUrl,
         @Schema(description = "레벨", example = "5")
         int level,
         @Schema(description = "회원이 달린 총 거리", example = "200.3")
@@ -19,7 +21,7 @@ public record GetMemberResponse(
         double totalKcal
 ) {
     public static GetMemberResponse from(Member member) {
-        return new GetMemberResponse(member.getMemberNo(), member.getNickname(), member.getRunDataVO().getLevel(),
+        return new GetMemberResponse(member.getMemberNo(), member.getNickname(), member.getProfileImageUrl(), member.getRunDataVO().getLevel(),
                 member.getRunDataVO().getTotalDistance(), member.getRunDataVO().getDistanceToNextLevel(),
                 member.getRunDataVO().getTotalKcal());
     }

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/member/response/UpdateProfileImageResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/member/response/UpdateProfileImageResponse.java
@@ -1,0 +1,12 @@
+package com.runninghi.runninghibackv2.application.dto.member.response;
+
+import com.runninghi.runninghibackv2.domain.entity.Member;
+
+public record UpdateProfileImageResponse(
+        Long memberNo,
+        String profileImageUrl
+) {
+    public static UpdateProfileImageResponse of (Member member) {
+        return new UpdateProfileImageResponse(member.getMemberNo(), member.getProfileImageUrl());
+    }
+}

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/memberchallenge/response/GetChallengeRankingResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/memberchallenge/response/GetChallengeRankingResponse.java
@@ -4,6 +4,6 @@ public interface GetChallengeRankingResponse {
     Long getMemberChallengeId();
     float getRecord();
     String getNickname();
-    String getProfileUrl();
+    String getProfileImageUrl();
     int getRank();
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/post/response/GetAllPostsResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/post/response/GetAllPostsResponse.java
@@ -5,7 +5,6 @@ import com.runninghi.runninghibackv2.domain.entity.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record GetAllPostsResponse(
         @Schema(description = "게시글 번호", example = "1")
@@ -40,7 +39,7 @@ public record GetAllPostsResponse(
                 post.getPostContent(),
                 post.getRole(),
                 post.getMember().getNickname(),
-                post.getMember().getProfileUrl(),
+                post.getMember().getProfileImageUrl(),
                 post.getMainData(),
                 imageUrl,
                 isBookmarked,

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/post/response/GetMyPostsResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/post/response/GetMyPostsResponse.java
@@ -5,7 +5,6 @@ import com.runninghi.runninghibackv2.domain.entity.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record GetMyPostsResponse(
         @Schema(description = "게시글 번호", example = "1")
@@ -41,7 +40,7 @@ public record GetMyPostsResponse(
                 post.getPostContent(),
                 post.getRole(),
                 post.getMember().getNickname(),
-                post.getMember().getProfileUrl(),
+                post.getMember().getProfileImageUrl(),
                 post.getMainData(),
                 imageUrl,
                 isBookmarked,

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/post/response/GetPostResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/post/response/GetPostResponse.java
@@ -1,14 +1,10 @@
 package com.runninghi.runninghibackv2.application.dto.post.response;
 
-import com.runninghi.runninghibackv2.application.dto.reply.response.GetPostReplyResponse;
-import com.runninghi.runninghibackv2.domain.entity.vo.GpsDataVO;
 import com.runninghi.runninghibackv2.domain.enumtype.Role;
-import com.runninghi.runninghibackv2.domain.entity.Keyword;
 import com.runninghi.runninghibackv2.domain.entity.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record GetPostResponse(
 
@@ -56,7 +52,7 @@ public record GetPostResponse(
     public static GetPostResponse from(Post post, String imageUrl, Long likeCnt,Long bookmarkCnt, Long replyCnt, Boolean isOwner, Boolean isLiked, Boolean isBookmarked) {
         return new GetPostResponse(
                 post.getMember().getNickname(),
-                post.getMember().getProfileUrl(),
+                post.getMember().getProfileImageUrl(),
                 post.getMember().getRunDataVO().getLevel(),
                 post.getCreateDate(),
                 post.getPostContent(),

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/post/response/GetReportedPostsResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/post/response/GetReportedPostsResponse.java
@@ -5,7 +5,6 @@ import com.runninghi.runninghibackv2.domain.entity.Post;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record GetReportedPostsResponse(
         @Schema(description = "게시글 번호", example = "1")
@@ -32,7 +31,7 @@ public record GetReportedPostsResponse(
                 post.getPostContent(),
                 post.getRole(),
                 post.getMember().getNickname(),
-                post.getMember().getProfileUrl(),
+                post.getMember().getProfileImageUrl(),
                 post.getGpsDataVO().getKcal(),
                 imageUrl
         );

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/reply/GetReplyList.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/reply/GetReplyList.java
@@ -18,7 +18,7 @@ public class GetReplyList {
         @Schema(description = "댓글 작성자 닉네임", example = "러너1")
         String memberName;
         @Schema(description = "프로필 이미지", example = "회원 프로필 사진")
-        String profileUrl;
+        String profileImageUrl;
         @Schema(description = "게시글 번호", example = "1")
         Long postNo;
         @Schema(description = "댓글 내용", example = "댓글 내용")
@@ -34,11 +34,11 @@ public class GetReplyList {
         @Schema(description = "댓글 수정 여부", example = "false")
         Boolean isUpdated;
 
-    public GetReplyList(Long replyNo, Long memberNo, String memberName, String profileUrl, Long postNo, String replyContent, int reportedCount, boolean isDeleted, LocalDateTime createDate, LocalDateTime updateDate) {
+    public GetReplyList(Long replyNo, Long memberNo, String memberName, String profileImageUrl, Long postNo, String replyContent, int reportedCount, boolean isDeleted, LocalDateTime createDate, LocalDateTime updateDate) {
         this.replyNo = replyNo;
         this.memberNo = memberNo;
         this.memberName = memberName;
-        this.profileUrl = profileUrl;
+        this.profileImageUrl = profileImageUrl;
         this.postNo = postNo;
         this.replyContent = replyContent;
         this.reportedCount = reportedCount;

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/reply/response/UpdateReplyResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/reply/response/UpdateReplyResponse.java
@@ -11,7 +11,7 @@ public record UpdateReplyResponse (
         @Schema(description = "댓글 작성자 닉네임", example = "러너1")
         String memberName,
         @Schema(description = "댓글 작성자 프로필 이미지", example = "profile.png")
-        String profileUrl,
+        String profileImageUrl,
         @Schema(description = "게시글 번호", example = "1")
         Long postNo,
         @Schema(description = "댓글 내용", example = "댓글 내용")
@@ -29,7 +29,7 @@ public record UpdateReplyResponse (
         return new UpdateReplyResponse(
                 reply.getReplyNo(),
                 reply.getMember().getNickname(),
-                reply.getMember().getProfileUrl(),
+                reply.getMember().getProfileImageUrl(),
                 reply.getPost().getPostNo(),
                 reply.getReplyContent(),
                 reply.isDeleted(),

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/AppleOauthService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/AppleOauthService.java
@@ -49,6 +49,9 @@ public class AppleOauthService {
     @Value("${apple.client-id}")
     private String clientId;
 
+    @Value("${cloud.aws.s3.default-profile}")
+    private String defaultProfileImageUrl;
+
     // client secret 생성
     @Transactional
     public String createClientSecret() {
@@ -199,6 +202,7 @@ public class AppleOauthService {
                 .name(appleResponse.get("name"))
                 .appleRefreshToken(appleRefreshToken)
                 .nickname("러너 " + generateRandomDigits())
+                .profileImageUrl(defaultProfileImageUrl)
                 .isActive(true)
                 .isBlacklisted(false)
                 .isTermsAgreed(false)

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/ImageService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/ImageService.java
@@ -1,6 +1,5 @@
 package com.runninghi.runninghibackv2.application.service;
 
-import com.runninghi.runninghibackv2.application.dto.image.response.CreateImageResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/KakaoOauthService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/KakaoOauthService.java
@@ -29,13 +29,16 @@ import java.util.*;
 @RequiredArgsConstructor
 public class KakaoOauthService {
 
-    private static final int NICKNAME_DIGIT_LENGTH = 8;
+    private static final int NICKNAME_DIGIT_LENGTH = 5;
     private static final int RANDOM_NUMBER_RANGE = 10;
     private static final String KAKAO_USER_INFO_REQUEST_URL = "https://kapi.kakao.com/v2/user/me";
     private static final String KAKAO_UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
 
     @Value("${kakao.admin-key}")
     private String adminKey;
+
+    @Value("${cloud.aws.s3.default-profile}")
+    private String defaultProfileImageUrl;
 
     private final RestTemplate restTemplate;
     private final JwtTokenProvider jwtTokenProvider;
@@ -85,7 +88,7 @@ public class KakaoOauthService {
 
         // 필요한 사용자 정보 가져오기
         MultiValueMapAdapter<String, String> body = new LinkedMultiValueMap<>();
-        body.add("property_keys", "[\"id\", \"properties.nickname\"]");
+        body.add("property_keys", "[\"id\", \"properties.profileNickname\"]");
 
         HttpEntity<?> request = new HttpEntity<>(body, headers);
 
@@ -132,6 +135,7 @@ public class KakaoOauthService {
         Member member = Member.builder()
                 .kakaoId(kakaoProfile.getKakaoId().toString())
                 .name(kakaoProfile.getNickname())
+                .profileImageUrl(defaultProfileImageUrl)
                 .nickname("러너 " + generateRandomDigits())
                 .isActive(true)
                 .isBlacklisted(false)

--- a/src/main/java/com/runninghi/runninghibackv2/common/exception/custom/ImageException.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/exception/custom/ImageException.java
@@ -1,0 +1,12 @@
+package com.runninghi.runninghibackv2.common.exception.custom;
+
+public class ImageException extends RuntimeException{
+    public ImageException() {}
+    public ImageException(String message) {
+        super(message);
+    }
+    public ImageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/com/runninghi/runninghibackv2/domain/entity/Member.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/entity/Member.java
@@ -37,7 +37,7 @@ public class Member extends BaseTimeEntity {
 
     @Column
     @Comment("프로필 이미지 url")
-    private String profileUrl;
+    private String profileImageUrl;
 
     @Column
     @Comment("카카오 로그인 : id")
@@ -101,7 +101,7 @@ public class Member extends BaseTimeEntity {
     private boolean isTermsAgreed = false;
 
     @Builder
-    public Member(Long memberNo, String account, String password, String nickname, String profileUrl, String kakaoId, String name,
+    public Member(Long memberNo, String account, String password, String nickname, String profileImageUrl, String kakaoId, String name,
                   String appleId, int reportCnt, boolean isActive, boolean isBlacklisted, Role role, String refreshToken,
                   String appleRefreshToken, String fcmToken, boolean alarmConsent, LocalDateTime deactivateDate,
                   RunDataVO runDataVO, Point geometry, boolean isTermsAgreed) {
@@ -109,7 +109,7 @@ public class Member extends BaseTimeEntity {
         this.account = account;
         this.password = password;
         this.nickname = nickname;
-        this.profileUrl = profileUrl;
+        this.profileImageUrl = profileImageUrl;
         this.kakaoId = kakaoId;
         this.name = name;
         this.appleId = appleId;
@@ -164,6 +164,10 @@ public class Member extends BaseTimeEntity {
 
     public void updateGeometry(Point geometry) {
         this.geometry = geometry;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 
     public void cleanupDeactivateMemberData() {

--- a/src/main/java/com/runninghi/runninghibackv2/domain/repository/MemberChallengeRepository.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/repository/MemberChallengeRepository.java
@@ -20,12 +20,12 @@ public interface MemberChallengeRepository extends JpaRepository<MemberChallenge
     List<MemberChallenge> findByMemberAndChallengeStatus(@Param("member") Member member, @Param("status") boolean status);
 
     @Query("SELECT m.memberChallengeId AS memberChallengeId, m.record AS record, m.member.nickname AS nickname," +
-            "m.member.profileUrl AS profileUrl, RANK() OVER (ORDER BY m.record DESC) AS rank " +
+            "m.member.profileImageUrl AS profileImageUrl, RANK() OVER (ORDER BY m.record DESC) AS rank " +
             "FROM MemberChallenge m WHERE m.challenge.challengeNo = :challengeNo")
     List<GetChallengeRankingResponse> findChallengeRanking(@Param("challengeNo") Long challengeNo);
 
     @Query("SELECT m.memberChallengeId AS memberChallengeId, m.record AS record, m.member.nickname AS nickname, " +
-            "m.member.profileUrl AS profileUrl, " +
+            "m.member.profileImageUrl AS profileImageUrl, " +
             "(SELECT COUNT(*) + 1 FROM MemberChallenge m2 WHERE m2.challenge.challengeNo = :challengeNo AND m2.record > m.record) AS rank " +
             "FROM MemberChallenge m WHERE m.challenge.challengeNo = :challengeNo AND m.member.memberNo = :memberNo")
     GetChallengeRankingResponse findMemberRanking(@Param("challengeNo") Long challengeNo, @Param("memberNo") Long memberNo);

--- a/src/main/java/com/runninghi/runninghibackv2/domain/service/MemberChecker.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/service/MemberChecker.java
@@ -11,4 +11,8 @@ public class MemberChecker {
             throw new BadRequestException();
         }
     }
+
+    public boolean isCustomProfileImage(String currentProfileImageUrl, String defaultProfileImageUrl) {
+        return currentProfileImageUrl != null && !currentProfileImageUrl.isEmpty() && !currentProfileImageUrl.equals(defaultProfileImageUrl);
+    }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/infrastructure/repository/ReplyQueryRepositoryImpl.java
+++ b/src/main/java/com/runninghi/runninghibackv2/infrastructure/repository/ReplyQueryRepositoryImpl.java
@@ -44,7 +44,7 @@ public class ReplyQueryRepositoryImpl implements ReplyQueryRepository {
                         reply.replyNo,
                         reply.member.memberNo,
                         reply.member.nickname,
-                        reply.member.profileUrl,
+                        reply.member.profileImageUrl,
                         reply.post.postNo,
                         reply.replyContent,
                         reply.reportedCount,

--- a/src/test/java/com/runninghi/runninghibackv2/application/controller/FeedbackControllerTest.java
+++ b/src/test/java/com/runninghi/runninghibackv2/application/controller/FeedbackControllerTest.java
@@ -64,7 +64,7 @@ class FeedbackControllerTest {
         token = "mocked-jwt-token";
         title = "title";
         content = "content";
-        nickname = "nickname";
+        nickname = "profileNickname";
         responseStatus = "OK";
         feedbackNo = 1L;
         memberNo = 1L;


### PR DESCRIPTION
## 📌 관련 이슈 #522

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

- closed #522 

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- 프로필 이미지 수정 기능
  - member 테이블의 프로필 이미지 컬럼명을 ```profileUrl```에서 ```profileImaeUrl```로 변경 -> 해당 컬럼을 조회하는 다른 도메인의 변수명도 전부 ```profileImageUrl```로 수정
  - 회원가입 시 애플/카카오 로그인에 상관없이 기본 프로필 이미지 url로 설정함
  - 프로필 이미지 수정 시 ```profile/{memberNo}/```에 이미지가 저장됨.
  - 프로필 이미지 삭제 시 기본 프로필 이미지로 변경되도록 함. 

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 기본 프로필 이미지는 default_image.svg를 사용했습니다!
<!-- 참고할 사항이 있다면 적어주세요 -->
