### PR TITLE
[#538] BubFix : profileNickname을 nickname으로 변경, memberNo를 응답값에 추가

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/service/KakaoOauthService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/KakaoOauthService.java
@@ -88,7 +88,7 @@ public class KakaoOauthService {
 
         // 필요한 사용자 정보 가져오기
         MultiValueMapAdapter<String, String> body = new LinkedMultiValueMap<>();
-        body.add("property_keys", "[\"id\", \"properties.profileNickname\"]");
+        body.add("property_keys", "[\"id\", \"properties.nickname\"]");
 
         HttpEntity<?> request = new HttpEntity<>(body, headers);
 
@@ -112,9 +112,8 @@ public class KakaoOauthService {
         Map<String, String> response = new HashMap<>();
         response.put("accessToken", accessToken);
         response.put("refreshToken", refreshToken);
+        response.put("memberNo", member.getMemberNo().toString());
 
-        if (isNewMember)
-            response.put("memberNo", member.getMemberNo().toString());
         log.info("새 회원 생성 후 멤버 번호 추가: {}", member.getMemberNo());
 
         return response;
@@ -125,6 +124,7 @@ public class KakaoOauthService {
         log.info("카카오 로그인을 수행합니다. 회원 번호: {}", member.getMemberNo());
 
         member.activateMember();  // 멤버의 활성화 상태를 true로 변경, deactivateDate를 null로 설정
+
         return generateTokens(member, false);
     }
 

--- a/src/test/java/com/runninghi/runninghibackv2/application/controller/FeedbackControllerTest.java
+++ b/src/test/java/com/runninghi/runninghibackv2/application/controller/FeedbackControllerTest.java
@@ -64,7 +64,7 @@ class FeedbackControllerTest {
         token = "mocked-jwt-token";
         title = "title";
         content = "content";
-        nickname = "profileNickname";
+        nickname = "nickname";
         responseStatus = "OK";
         feedbackNo = 1L;
         memberNo = 1L;


### PR DESCRIPTION
## 📌 관련 이슈 #538

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #538

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

-  카카오 로그인 시 응답의 memberNo가 null : meberNo를 Map<String,String>에 추가해서 반환하도록 수정
-  카카오 회원가입 시 닉네임을 제대로 가져오지 못하는 문제 : profileNickname을 nickname으로 수정
