### PR TITLE
[#579] POST 삭제 시 해당하는 RECORD 삭제

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/service/PostService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/PostService.java
@@ -14,6 +14,7 @@ import com.runninghi.runninghibackv2.common.response.PageResultData;
 import com.runninghi.runninghibackv2.domain.entity.Member;
 import com.runninghi.runninghibackv2.domain.entity.MemberChallenge;
 import com.runninghi.runninghibackv2.domain.entity.Post;
+import com.runninghi.runninghibackv2.domain.entity.Record;
 import com.runninghi.runninghibackv2.domain.entity.vo.GpsDataVO;
 import com.runninghi.runninghibackv2.domain.enumtype.*;
 import com.runninghi.runninghibackv2.domain.repository.*;
@@ -259,8 +260,6 @@ public class PostService {
             String gpsUrl = uploadGpsToS3(file, member.getMemberNo().toString());
 
             int nowLevel = member.getRunDataVO().getLevel();
-
-            recordService.createRecord(member, gpsDataVO);
             member.getRunDataVO().updateTotalDistanceKcalAndLevel(gpsDataVO.getDistance(), gpsDataVO.getKcal());
 
             int updateLevel = member.getRunDataVO().getLevel();
@@ -286,7 +285,7 @@ public class PostService {
                     .status(false)
                     .postTitle(createPostTitle(gpsDataVO))
                     .build());
-
+            recordService.createRecord(member, gpsDataVO, createdPost.getPostNo());
             updateRecordOfMemberChallenges(memberNo, gpsDataVO);
 
             return new CreateRecordResponse(createdPost.getPostNo());
@@ -355,6 +354,7 @@ public class PostService {
 
         try {
             postRepository.deleteById(postNo);
+            recordService.deleteRecord(postNo);
         } catch (Exception e) {
             log.error("게시글 삭제 중 오류 발생. 회원번호: {}, 게시글 번호: {}", memberNo, postNo, e);
             throw e;

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/RecordService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/RecordService.java
@@ -9,10 +9,12 @@ import com.runninghi.runninghibackv2.domain.entity.vo.GpsDataVO;
 import com.runninghi.runninghibackv2.domain.repository.RecordQueryRepository;
 import com.runninghi.runninghibackv2.domain.repository.RecordRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RecordService {
@@ -20,7 +22,7 @@ public class RecordService {
     private final RecordRepository recordRepository;
     private final RecordQueryRepository recordQueryRepository;
 
-    public void createRecord(Member member, GpsDataVO recordData) {
+    public void createRecord(Member member, GpsDataVO recordData, Long targetNo) {
 
         Record runRecord = Record.builder()
                 .member(member)
@@ -29,6 +31,7 @@ public class RecordService {
                 .distance(recordData.getDistance())
                 .time(recordData.getTime())
                 .date(LocalDate.from(recordData.getRunStartTime()))
+                .targetNo(targetNo)
                 .build();
 
         recordRepository.save(runRecord);
@@ -45,5 +48,14 @@ public class RecordService {
 
     public GetYearlyRecordResponse getYearlyRecord(Long memberNo, LocalDate date) {
         return recordQueryRepository.getYearlyRecord(memberNo, date);
+    }
+
+    public void deleteRecord(Long targetNo) {
+        try {
+            recordRepository.deleteByTargetNo(targetNo);
+        } catch (Exception e) {
+            log.error("기록 삭제 중 오류 발생. 관련 게시글 번호: {}",  targetNo, e);
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/domain/entity/Record.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/entity/Record.java
@@ -46,13 +46,18 @@ public class Record {
     @Comment("날짜")
     private LocalDate date;
 
+    @Column
+    @Comment(value = "POST 엔티티 식별 값")
+    private Long targetNo;
+
     @Builder
-    public Record(Member member, Float distance, int time, int meanPaceSec, int kcal, LocalDate date) {
+    public Record(Member member, Float distance, int time, int meanPaceSec, int kcal, LocalDate date, Long targetNo) {
         this.member = member;
         this.distance = distance;
         this.time = time;
         this.meanPaceSec = meanPaceSec;
         this.kcal = kcal;
         this.date = date;
+        this.targetNo = targetNo;
     }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/domain/repository/RecordRepository.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/repository/RecordRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecordRepository extends JpaRepository<Record, Long> {
+    void deleteByTargetNo(Long targetNo);
+
 }


### PR DESCRIPTION
## 📌 관련 이슈

* closed #579 

## ✨ 과제 내용

- 게시글 삭제 시 해당하는 기록 삭제되도록 수정
- Record 엔티티에 targetNo 칼럼 추가

##  💩 참고
- 이런식으로 POST 와 1:1 대응하는 RECORD 만들 수 있어요

```sql
INSERT INTO TBL_RECORD (MEMBER_NO, distance, time, mean_pace_sec, kcal, date, target_no)
SELECT
    member_no,
    distance,
    time,
    mean_pace,
    kcal,
    DATE(create_date),
    post_no
FROM tbl_post
WHERE member_no IS NOT NULL
  AND distance IS NOT NULL
  AND time IS NOT NULL
  AND mean_pace IS NOT NULL
  AND kcal IS NOT NULL
  AND create_date IS NOT NULL
  AND post_no IS NOT NULL;
```