### PR TITLE
[#593][Bugfix] 프로필 업데이트 오류 수정

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/service/MemberService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/MemberService.java
@@ -245,7 +245,6 @@ public class MemberService {
         if (memberChecker.isCustomProfileImage(currentProfileImageUrl, defaultProfileImageUrl)) {
             try {
                 // cloud starage의 이미지 삭제 로직
-                imageService.deleteImageFromDB(currentProfileImageUrl);
                 imageService.deleteImageFromStorage(currentProfileImageUrl);
                 log.info("기존 프로필 이미지 삭제 완료: {}", currentProfileImageUrl);
             } catch (Exception e) {
@@ -254,15 +253,15 @@ public class MemberService {
             }
         }
 
-        String profileImageUrl;
+        String newProfileImageUrl;
         try {
-            profileImageUrl = imageService.uploadImage(profileImage, memberNo, "profile/");
+            newProfileImageUrl = imageService.uploadImage(profileImage, memberNo, "profile/");
         } catch (IOException e) {
             log.error("이미지 업로드 중 오류 발생: {}", e.getMessage());
             throw new ImageException("프로필 이미지 업로드 중 오류가 발생했습니다.");
         }
 
-        member.updateProfileImageUrl(profileImageUrl);
+        member.updateProfileImageUrl(newProfileImageUrl);
 
         return UpdateProfileImageResponse.of(member);
     }


### PR DESCRIPTION
## 📌 관련 이슈 ##593

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

- closed #593

## ✨ 과제 내용

<!-- 과제에 대한 설명을 적어주세요 -->

- Image 도메인에 프로필 이미지도 같이 저장된다고 생각해서 ImageRepository로 이미지 삭제 시도
  -> Image 도메인에는 포스트와 관련된 imageUrl밖에 없기 때문에 db에 존재하지않는다는 에러 발생
- Imga 도메인이 아니라 Storage에서만 이미지를 삭제하도록 수정


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

- Profile Image도 Image 도메인에 저장된다고 착각했네요ㅠ...  현재 Image 도메인에 저장되는 이미지는 Post Image 밖에 없다구 합니다...