### PR TITLE
[#647] 알림 서비스 이동 및 데이터 분리 구현

### DIFF
--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/alarm/request/CreateAlarmRequest.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/alarm/request/CreateAlarmRequest.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
+import java.util.Map;
+
 @Getter
 @Setter
 @Builder
@@ -29,8 +31,19 @@ public class CreateAlarmRequest {
         @Schema(description = "관련 식별 값", example = "234")
         private Long targetId;
 
+        @Schema(description = "부가 정보", example = "{\"key1\": \"value1\", \"key2\": \"value2\"}")
+        private Map<String, String> additionalData;
+
         @Schema(description = "FCM 토큰")
         @NotBlank(message = "토큰을 포함시켜주세요.")
         private String fcmToken;
 
+        public CreateAlarmRequest(String title, Long targetMemberNo, AlarmType alarmType, TargetPage targetPage, Long targetId, String fcmToken) {
+                this.title = title;
+                this.targetMemberNo = targetMemberNo;
+                this.alarmType = alarmType;
+                this.targetPage = targetPage;
+                this.targetId = targetId;
+                this.fcmToken = fcmToken;
+        }
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/dto/alarm/response/GetAllAlarmResponse.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/dto/alarm/response/GetAllAlarmResponse.java
@@ -24,6 +24,7 @@ public record GetAllAlarmResponse(
         LocalDateTime createDate
 ) {
         public static GetAllAlarmResponse ofAlarmEntity(Alarm alarm) {
+
                 return new GetAllAlarmResponse(
                         alarm.getId(),
                         alarm.getTitle(),
@@ -33,5 +34,7 @@ public record GetAllAlarmResponse(
                         alarm.isRead(),
                         alarm.getCreateDate()
                 );
+
         }
+
 }

--- a/src/main/java/com/runninghi/runninghibackv2/application/service/AlarmService.java
+++ b/src/main/java/com/runninghi/runninghibackv2/application/service/AlarmService.java
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import com.runninghi.runninghibackv2.application.dto.alarm.request.CreateAlarmRequest;
 import com.runninghi.runninghibackv2.application.dto.alarm.response.GetAllAlarmResponse;
+import com.runninghi.runninghibackv2.common.constant.AlarmConstants;
 import com.runninghi.runninghibackv2.common.exception.custom.FcmException;
 import com.runninghi.runninghibackv2.domain.entity.Alarm;
 import com.runninghi.runninghibackv2.domain.entity.Member;
@@ -72,6 +73,7 @@ public class AlarmService {
                 .alarmType(request.getAlarmType())
                 .targetPage(request.getTargetPage())
                 .targetId(request.getTargetId())
+                .additionalData(request.getAdditionalData())
                 .build();
 
         alarmRepository.save(alarm);
@@ -91,11 +93,14 @@ public class AlarmService {
     private void sendPushAlarm(CreateAlarmRequest request) throws FirebaseMessagingException {
 
         Notification notification = Notification.builder()
-                .setTitle(request.getTitle())
+                .setTitle(AlarmConstants.title)
+                .setBody(request.getTitle())
                 .build();
+
         Message message = Message.builder()
                 .setToken(request.getFcmToken())
                 .setNotification(notification)
+                .putAllData(request.getAdditionalData())
                 .build();
 
         firebaseMessaging.send(message);

--- a/src/main/java/com/runninghi/runninghibackv2/common/constant/AlarmConstants.java
+++ b/src/main/java/com/runninghi/runninghibackv2/common/constant/AlarmConstants.java
@@ -1,0 +1,6 @@
+package com.runninghi.runninghibackv2.common.constant;
+
+public class AlarmConstants {
+
+    public static final String title = "러닝하이";
+}

--- a/src/main/java/com/runninghi/runninghibackv2/domain/entity/Alarm.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/entity/Alarm.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.*;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -51,6 +52,12 @@ public class Alarm {
     @Comment(value = "관련 식별 값")
     private Long targetId;
 
+    @ElementCollection
+    @CollectionTable(name = "alarm_additional_data", joinColumns = @JoinColumn(name = "alarm_no"))
+    @MapKeyColumn(name = "data_key")
+    @Column(name = "data_value")
+    private Map<String, String> additionalData;
+
     @Column(name = "is_read", nullable = false)
     @ColumnDefault(value = "false")
     @Comment(value = "확인 여부")
@@ -66,13 +73,14 @@ public class Alarm {
     private LocalDateTime readDate;
 
     @Builder
-    public Alarm(Long id, Member member, String title, AlarmType alarmType, TargetPage targetPage, Long targetId, LocalDateTime readDate) {
+    public Alarm(Long id, Member member, String title, AlarmType alarmType, TargetPage targetPage, Long targetId, Map<String, String> additionalData, LocalDateTime readDate) {
         this.id = id;
         this.member = member;
         this.title = title;
         this.alarmType = alarmType;
         this.targetPage = targetPage;
         this.targetId = targetId;
+        this.additionalData = additionalData;
         this.isRead = false;
         this.createDate = LocalDateTime.now();
         this.readDate = LocalDateTime.now();

--- a/src/main/java/com/runninghi/runninghibackv2/domain/entity/Alarm.java
+++ b/src/main/java/com/runninghi/runninghibackv2/domain/entity/Alarm.java
@@ -53,7 +53,7 @@ public class Alarm {
     private Long targetId;
 
     @ElementCollection
-    @CollectionTable(name = "alarm_additional_data", joinColumns = @JoinColumn(name = "alarm_no"))
+    @CollectionTable(name = "tbl_alarm_additional_data", joinColumns = @JoinColumn(name = "alarm_no"))
     @MapKeyColumn(name = "data_key")
     @Column(name = "data_value")
     private Map<String, String> additionalData;


### PR DESCRIPTION
## 📌 관련 이슈
- closed #646 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- pdf 자료로 정리된 것처럼, 푸쉬 알림의 title은 '러닝하이'로 고정, content에 기존에 알림으로 사용되던 알림 내용이 담겨집니다.
- 부가 정보가 있을 것이라 판단하여 Map 형태로 `부가 정보`를 알림에 data로 보낼 수 있도록 업데이트 하였습니다.
ex) 댓글 알림 시에, targetId로 postNo, 부가 정보에 replyNo : "1"로 담겨집니다.
- 추가로, 엔티티로 조회되도록 `@ElementCollection`을 이용해 hibernate가 객체 연관관계를 기반으로 테이블을 자동 생성하도록 설정하였습니다.

```java

    @ElementCollection
    @CollectionTable(name = "tbl_alarm_additional_data", joinColumns = @JoinColumn(name = "alarm_no"))
    @MapKeyColumn(name = "data_key")
    @Column(name = "data_value")
    private Map<String, String> additionalData;
    
```

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

<br>
<br>
